### PR TITLE
Invariant counterfactual fairness metrics

### DIFF
--- a/src/FAI3_backend/FAI3_backend.did
+++ b/src/FAI3_backend/FAI3_backend.did
@@ -106,6 +106,12 @@ type LLMDataPoint = record {
     error: bool;
 };
 
+type CounterFactualModelEvaluationResult = record {
+  change_rate_overall: float32;
+  change_rate_sensible_attributes: vec float32;
+  total_sensible_attributes: vec nat32;
+};
+
 type ModelEvaluationResult = record {
     model_evaluation_id: nat;
     dataset: text;
@@ -115,6 +121,7 @@ type ModelEvaluationResult = record {
     data_points: opt vec DataPoint;
     llm_data_points: opt vec LLMDataPoint;
     prompt_template: opt text;
+    counter_factual: opt CounterFactualModelEvaluationResult;
 };
 
 type LLMModelData = record {
@@ -172,6 +179,7 @@ type LLM_MetricsAPIResult = record {
     queries: nat64;
     invalid_responses: nat32;
     call_errors: nat32;
+    counter_factual: opt CounterFactualModelEvaluationResult;
 };
 
 service : () -> {

--- a/src/FAI3_backend/src/types.rs
+++ b/src/FAI3_backend/src/types.rs
@@ -18,6 +18,18 @@ pub struct DataPoint {
     pub(crate) timestamp: u64,
 }
 
+#[derive(CandidType, CandidDeserialize, Clone, Debug)]
+pub struct LLMDataPointCounterFactual {
+    pub(crate) prompt: Option<String>,
+    pub(crate) response: Option<String>,
+    pub(crate) valid: bool,
+    pub(crate) error: bool,
+    pub(crate) target: bool,
+    pub(crate) timestamp: u64,
+    pub(crate) predicted: Option<bool>,
+    pub(crate) features: Vec<f64>,
+}
+
 // Represents a data point for using LLMs as classifiers
 // So the same classifier metrics can be calculated over this
 #[derive(CandidType, CandidDeserialize, Clone, Debug)]
@@ -31,6 +43,7 @@ pub struct LLMDataPoint {
     pub(crate) response: Option<String>,
     pub(crate) valid: bool,
     pub(crate) error: bool,
+    pub(crate) counter_factual: Option<LLMDataPointCounterFactual>,
 }
 
 impl LLMDataPoint { 
@@ -62,6 +75,14 @@ pub(crate) struct KeyValuePair {
 }
 
 #[derive(CandidType, CandidDeserialize, Clone, Debug)]
+pub struct CounterFactualModelEvaluationResult {
+    pub(crate) change_rate_overall: f32,
+    pub(crate) change_rate_sensible_attributes: Vec<f32>,
+    pub(crate) total_sensible_attributes: Vec<u32>,
+    pub(crate) sensible_attribute: String,
+}
+
+#[derive(CandidType, CandidDeserialize, Clone, Debug)]
 pub struct ModelEvaluationResult {
     pub(crate) model_evaluation_id: u128,
     pub(crate) dataset: String,
@@ -73,6 +94,7 @@ pub struct ModelEvaluationResult {
     pub(crate) data_points: Option<Vec<DataPoint>>,
     pub(crate) llm_data_points: Option<Vec<LLMDataPoint>>,
     pub(crate) prompt_template: Option<String>,
+    pub(crate) counter_factual: Option<CounterFactualModelEvaluationResult>,
 }
 
 #[derive(CandidType, CandidDeserialize, Clone, Debug)]
@@ -292,4 +314,5 @@ pub struct LLMMetricsAPIResult {
     pub queries: usize,
     pub invalid_responses: u32,
     pub call_errors: u32,
+    pub counter_factual: Option<CounterFactualModelEvaluationResult>,
 }


### PR DESCRIPTION
Adds invariant counterfactual fairness (changing the sensible column to the fairness metrics dataset evaluation) so it can be measured if the LLM model changes its answer.

Based on "Fairness of ChatGPT" paper: 

How to test:

Requirement: having an LLM created on the canister.

```
dfx canister call FAI3_backend add_llm_model '("Mistral-Nemo-Instruct-2407", "mistralai/Mistral-Nemo-Instruct-2407", record {
    description = "Your model description";
    framework = "TensorFlow";
    version = "2.0";
    objective = "Image classification";
    url = "https://example.com/model"
  })'
  ```

Just callilng calculate_llm_metrics will actually run also the invariant counterfactual fairness test.

    dfx canister call FAI3_backend calculate_llm_metrics '(1:nat, "pisa": text, 10:nat64, 1:nat32)'

Results will be in the answer and also saved in the model:

```
(
  variant {
    Ok = record {
      // ...
      counter_factual = opt record {
        total_sensible_attributes = vec { 2 : nat32; 4 : nat32 };
        change_rate_overall = 0.0 : float32;  // overall change rate
        change_rate_sensible_attributes = vec { 0.0 : float32; 0.0 : float32 };  // change rate by sensible attribute (same indices as the dataset)
      };
      // ...
    }
  },
)
```

Results are also saved in the model:

    dfx canister call FAI3_backend get_model '(1:nat)'
    
```
            counter_factual = opt record {
              total_sensible_attributes = vec { 2 : nat32; 4 : nat32 };
              change_rate_overall = 0.0 : float32;
              change_rate_sensible_attributes = vec {
                0.0 : float32;
                0.0 : float32;
              };
            };
```