### PR TITLE
Make hugging face api key configurable

### DIFF
--- a/src/FAI3_backend/FAI3_backend.did
+++ b/src/FAI3_backend/FAI3_backend.did
@@ -261,4 +261,7 @@ service : () -> {
     "get_llm_model_data_id": (nat) -> (LLMModelData) query;
 
     "context_association_test": (nat, nat64, nat32, bool) -> (variant { Ok: ContextAssociationTestAPIResult; Err: GenericError });
+
+    "set_config": (text, text) -> ();
+    "get_config": (text) -> (variant { Ok: text; Err: GenericError }) query;
 }

--- a/src/FAI3_backend/src/config_management.rs
+++ b/src/FAI3_backend/src/config_management.rs
@@ -1,0 +1,34 @@
+use crate::{
+    check_cycles_before_action, CONFIGURATION,
+};
+use crate::errors::GenericError;
+use crate::admin_management::only_admin;
+
+pub const HUGGING_FACE_API_KEY_CONFIG_KEY: &str = "hugging_face_api_key";
+
+#[ic_cdk::update]
+pub fn set_config(config_key: String, config_value: String) {
+    check_cycles_before_action();
+    only_admin();
+
+    CONFIGURATION.with(|config| {
+        let mut config_tree = config.borrow_mut();
+        config_tree.insert(config_key, config_value);
+    });
+}
+
+#[ic_cdk::query]
+pub fn get_config(config_key: String) -> Result<String, GenericError> {
+    check_cycles_before_action();
+    only_admin();
+
+    let result = CONFIGURATION.with(|config| {
+        let config_tree = config.borrow();
+        config_tree.get(&config_key)
+    });
+
+    match result {
+        Some(value) => return Ok(value),
+        None => return Err(GenericError::new(GenericError::CONFIGURATION_KEY_NOT_FOUND, "Key not set")),
+    }
+}

--- a/src/FAI3_backend/src/errors.rs
+++ b/src/FAI3_backend/src/errors.rs
@@ -19,6 +19,7 @@ impl GenericError {
     // Resource error: 300
     // External resource error: 400
     // Internal error: 500
+    // Configuration error: 600
 
     // Specific errors within categories
     pub const EMPTY_INPUT: u16 = 101;
@@ -35,6 +36,8 @@ impl GenericError {
     pub const HUGGING_FACE_ERROR_RATE_REACHED: u16 = 401;
 
     pub const GENERIC_SYSTEM_FAILURE: u16 = 500;
+
+    pub const CONFIGURATION_KEY_NOT_FOUND: u16 = 601;
     
     pub fn new(code: u16, message: impl Into<String>) -> Self {
         let category: u16 = (code / 100) * 100;
@@ -56,5 +59,12 @@ impl GenericError {
 impl fmt::Display for GenericError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}: {}", self.code, self.message, )
+    }
+}
+
+
+impl From<GenericError> for String {
+    fn from(err: GenericError) -> Self {
+        format!("Error {}: {}", err.code, err.message)
     }
 }

--- a/src/FAI3_backend/src/hugging_face.rs
+++ b/src/FAI3_backend/src/hugging_face.rs
@@ -1,4 +1,5 @@
-
+use crate::CONFIGURATION;
+use crate::config_management::HUGGING_FACE_API_KEY_CONFIG_KEY;
 use serde::{Deserialize, Serialize};
 
 use ic_cdk::api::management_canister::http_request::{
@@ -9,7 +10,6 @@ use num_traits::cast::ToPrimitive;
 use crate::types::HuggingFaceResponseItem;
 
 const HUGGING_FACE_ENDPOINT: &str = "https://api-inference.huggingface.co/models";
-const HUGGING_FACE_BEARER_TOKEN: &str = "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";
 
 #[derive(Serialize, Deserialize, Clone)]
 pub struct HuggingFaceRequestParameters {
@@ -73,6 +73,13 @@ pub async fn call_hugging_face(input_text: String, llm_model: String, seed: u32,
 
     // ic_cdk::println!("{}", String::from_utf8(json_payload.clone()).unwrap());
 
+    let hugging_face_bearer_token = CONFIGURATION.with(|config| {
+        let config_tree = config.borrow();
+
+        let not_found_error_message = format!("{} config key should be set.", HUGGING_FACE_API_KEY_CONFIG_KEY.to_string());
+        return config_tree.get(&HUGGING_FACE_API_KEY_CONFIG_KEY.to_string()).expect(not_found_error_message.as_str());
+    });
+
     // 2) Prepare headers
     let headers = vec![
         HttpHeader {
@@ -81,7 +88,7 @@ pub async fn call_hugging_face(input_text: String, llm_model: String, seed: u32,
         },
         HttpHeader {
             name: "Authorization".to_string(),
-            value: format!("Bearer {}", HUGGING_FACE_BEARER_TOKEN),
+            value: format!("Bearer {}", hugging_face_bearer_token),
         },
     ];
 

--- a/src/FAI3_backend/src/lib.rs
+++ b/src/FAI3_backend/src/lib.rs
@@ -9,6 +9,8 @@ pub mod context_association_test;
 pub mod llm_fairness;
 mod utils;
 pub mod errors;
+mod config_management;
+
 use errors::GenericError;
 use candid::Principal;
 
@@ -71,6 +73,12 @@ thread_local! {
             MEMORY_MANAGER.with(|m| m.borrow().get(MemoryId::new(5))),
             1
         ).unwrap()
+    );
+
+    static CONFIGURATION: RefCell<StableBTreeMap<String, String, VirtualMemory<DefaultMemoryImpl>>> = RefCell::new(
+        StableBTreeMap::init(
+            MEMORY_MANAGER.with(|m| m.borrow().get(MemoryId::new(6)))
+        )
     );
 }
 

--- a/src/FAI3_backend/src/llm_fairness.rs
+++ b/src/FAI3_backend/src/llm_fairness.rs
@@ -6,6 +6,7 @@ use crate::utils::{is_owner, select_random_element, seeded_vector_shuffle};
 use crate::errors::GenericError;
 use std::collections::HashMap;
 use crate::metrics_calculation::{all_metrics, calculate_group_counts, accuracy, precision, recall, can_calculate_precision, can_calculate_recall, calculate_overall_confusion_matrix};
+use crate::config_management::{get_config, HUGGING_FACE_API_KEY_CONFIG_KEY};
 
 pub const PISA_PROMPT: &str = "Your task is to determine if the reading score of a student is L(low) or H (high) with the input attributes.\n\
 Perform the following actions:\n\
@@ -506,7 +507,6 @@ pub fn calculate_counter_factual_metrics(data_points: &Vec<LLMDataPoint>) -> (f3
     let mut changed_sensible_attr1: u32 = 0;
     let mut total_sensible_attr0: u32 = 0;
     let mut total_sensible_attr1: u32 = 0;
-    
 
     for dp in data_points {
         // We only calculate counter factual fairness on points that have no call errors,
@@ -565,6 +565,10 @@ pub fn calculate_counter_factual_metrics(data_points: &Vec<LLMDataPoint>) -> (f3
 #[update]
 pub async fn calculate_llm_metrics(llm_model_id: u128, dataset: String, max_queries: usize, seed: u32) -> Result<LLMMetricsAPIResult, String> {
     check_cycles_before_action();
+
+    // Checks that the HF api key is set
+    get_config(HUGGING_FACE_API_KEY_CONFIG_KEY.to_string())?;
+    
     let caller = ic_cdk::api::caller();
 
     ic_cdk::println!("Calling calculate_llm_metrics for model {}", llm_model_id);

--- a/src/FAI3_backend/tests/common/mod.rs
+++ b/src/FAI3_backend/tests/common/mod.rs
@@ -69,6 +69,21 @@ pub fn create_llm_model(pic: &PocketIc, canister_id: CanisterId, model_name: Str
     return decoded_reply;
 }
 
+/// Adds a mock Hugging Face API key to a model
+pub fn add_hf_api_key(pic: &PocketIc, canister_id: CanisterId, model_id: u128) {
+    let encoded_args = encode_args(("hugging_face_api_key", "fake-hf-api-key-value")).unwrap();
+    
+    // Testing add_classifier_model.
+    let update_call_reply = pic.update_call(
+        canister_id,
+        Principal::anonymous(),
+        "set_config",
+        encoded_args
+    ).expect("Failed to add a mocked Hugging Face API key");
+
+    decode_one::<()>(&update_call_reply).expect("Failed to decode create model reply");
+}
+
 pub fn get_all_models(pic: &PocketIc, canister_id: CanisterId) -> Vec<Model> {
     // Testing get_all_models method.
     let reply = pic.query_call(

--- a/src/FAI3_backend/tests/context_association_test.rs
+++ b/src/FAI3_backend/tests/context_association_test.rs
@@ -4,7 +4,7 @@ use FAI3_backend::errors::GenericError;
 use pocket_ic::PocketIc;
 mod common;
 use common::{
-    create_pic, create_llm_model, get_model,
+    create_pic, create_llm_model, get_model, add_hf_api_key,
     wait_for_http_request, mock_http_response, mock_correct_hugging_face_response_body
 };
 
@@ -19,6 +19,8 @@ fn cat_test(returned_texts: Vec<&str>) -> (PocketIc, Principal, u128, ContextAss
     let model_name = String::from("Test Model");
     let model_id: u128 = create_llm_model(&pic, canister_id, model_name.clone());
     assert_eq!(model_id, 1);
+
+    add_hf_api_key(&pic, canister_id, model_id);
 
     // Calling context_association_test
     let max_queries: usize = returned_texts.len();
@@ -68,6 +70,8 @@ fn test_llm_cat_generic_error_on_multiple_wrong_hugging_face_responses() {
     let model_name = String::from("Test Model");
     let model_id: u128 = create_llm_model(&pic, canister_id, model_name.clone());
     assert_eq!(model_id, 1);
+
+    add_hf_api_key(&pic, canister_id, model_id);
 
     // Calling context_association_test
     let max_queries: usize = 2;
@@ -121,6 +125,8 @@ fn test_llm_cat_test_wrong_hugging_face_responses() {
     let model_name = String::from("Test Model");
     let model_id: u128 = create_llm_model(&pic, canister_id, model_name.clone());
     assert_eq!(model_id, 1);
+
+    add_hf_api_key(&pic, canister_id, model_id);
 
     // Calling context_association_test
     let max_queries: usize = 4;

--- a/src/FAI3_backend/tests/llm_fairness.rs
+++ b/src/FAI3_backend/tests/llm_fairness.rs
@@ -9,7 +9,7 @@ use FAI3_backend::errors::GenericError;
 use std::collections::HashMap;
 mod common;
 use common::{
-    create_pic, create_llm_model, get_model,
+    create_pic, create_llm_model, get_model, add_hf_api_key,
     wait_for_http_request, mock_http_response, mock_correct_hugging_face_response_body
 };
 
@@ -85,6 +85,8 @@ fn llm_fairness_with_variable_queries_test(
     let model_name = String::from("Test Model");
     let model_id: u128 = create_llm_model(&pic, canister_id, model_name.clone());
     assert_eq!(model_id, 1);  // Assuming model creation is always returning model_id as 1 in mock
+
+    add_hf_api_key(&pic, canister_id, model_id);
 
     // Preparing the request with the dynamic number of max_queries based on returned_texts length
     let max_queries: usize = returned_texts.len();  // Now this is dynamic
@@ -185,6 +187,8 @@ fn test_llm_fairness_wrong_json_response() {
     let model_name = String::from("Test Model");
     let model_id: u128 = create_llm_model(&pic, canister_id, model_name.clone());
     assert_eq!(model_id, 1);
+
+    add_hf_api_key(&pic, canister_id, model_id);
 
     // Calling context_association_test
     let max_queries: usize = 2;
@@ -479,9 +483,11 @@ fn test_calculate_all_llm_metrics_integration() {
     let (pic, canister_id) = create_pic();
     let model_name = String::from("Test Model");
     let model_id: u128 = create_llm_model(&pic, canister_id, model_name);
+    add_hf_api_key(&pic, canister_id, model_id);
+
     let seed: u32 = 1;
     let max_queries: usize = 16;
-
+    
     // Submit an update call to the test canister to calculate all LLM metrics
     let encoded_args = encode_args((model_id, max_queries, seed)).unwrap();
     let call_id = pic.submit_call(
@@ -558,6 +564,9 @@ fn test_llm_fairness_datasets_integration_should_return_a_list_of_strings() {
 fn test_average_llm_metrics_integration_happy_path() {
     let (pic, canister_id) = create_pic();
     let model_id: u128 = create_llm_model(&pic, canister_id, "Test Model".to_string());
+
+    add_hf_api_key(&pic, canister_id, model_id);
+    
     let seed: u32 = 1;
     let max_queries: usize = 20;
 
@@ -702,6 +711,9 @@ fn test_average_llm_metrics_integration_happy_path() {
 fn test_average_llm_metrics_should_error_when_dataset_was_not_calculated() {
     let (pic, canister_id) = create_pic();
     let model_id: u128 = create_llm_model(&pic, canister_id, "Test Model".to_string());
+
+    add_hf_api_key(&pic, canister_id, model_id);
+    
     let seed: u32 = 1;
     let max_queries: usize = 16;
 


### PR DESCRIPTION
This PR makes hugging face api key configurable. It also allows to set custom configuration keys and values, as long they are strings.

How to test config:

```
dfx deploy FAI3_backend --mode=reinstall

dfx canister call FAI3_backend add_llm_model '("Mistral-Nemo-Instruct-2407", "mistralai/Mistral-Nemo-Instruct-2407", record {
    description = "Your model description";
    framework = "TensorFlow";
    version = "2.0";
    objective = "Image classification";
    url = "https://example.com/model"
  })'

# This call should fail with an error because the API key is not set
dfx canister call FAI3_backend calculate_llm_metrics '(1:nat, "pisa": text, 5:nat64, 1:nat32)'

dfx canister call FAI3_backend set_config '("hugging_face_api_key":text, "<some key value>": text)'

# You should be able to retrieve the same value you set
dfx canister call FAI3_backend get_config '("hugging_face_api_key":text)'

# Now the llm metrics call should work if you are using a valid key
dfx canister call FAI3_backend calculate_llm_metrics '(1:nat, "pisa": text, 5:nat64, 1:nat32)'
```