### PR TITLE
Kaleidoscope language evaluation benchmark

### DIFF
--- a/src/FAI3_backend/FAI3_backend.did
+++ b/src/FAI3_backend/FAI3_backend.did
@@ -98,6 +98,17 @@ type ContextAssociationTestMetricsBag = record {
 
 type HashMap = vec record { key: text; value: nat };
 
+type LLMDataPointCounterFactual = record {
+    prompt: opt text;
+    response: opt text;
+    valid: bool;
+    error: bool;
+    target: bool;
+    timestamp: nat64;
+    predicted: opt bool;
+    features: vec float64;
+};
+
 type LLMDataPoint = record {
     data_point_id: nat;
     target: bool;
@@ -108,12 +119,14 @@ type LLMDataPoint = record {
     response: opt text;
     valid: bool;
     error: bool;
+    counter_factual: opt LLMDataPointCounterFactual;
 };
 
 type CounterFactualModelEvaluationResult = record {
   change_rate_overall: float32;
   change_rate_sensible_attributes: vec float32;
   total_sensible_attributes: vec nat32;
+  sensible_attribute: text;
 };
 
 type ModelEvaluationResult = record {
@@ -133,6 +146,8 @@ type LLMModelData = record {
      cat_metrics: opt ContextAssociationTestMetricsBag;
      cat_metrics_history: vec ContextAssociationTestMetricsBag;
      evaluations: vec ModelEvaluationResult;
+     language_evaluations: vec LanguageEvaluationResult;
+     average_fairness_metrics: opt AverageLLMFairnessMetrics;
 };
 
 type ModelType = variant {
@@ -199,7 +214,8 @@ type ModelDetailsHistory = record {
   details: ModelDetails;
   version: nat;
   timestamp: nat64;
-  
+};
+
 type LLMMetricsAPIResult = record {
   "metrics": Metrics;
   "queries": nat64;
@@ -219,6 +235,36 @@ type AverageLLMFairnessMetrics = record {
   recall: float32;
   counter_factual_overall_change_rate: float32;
   model_evaluation_ids: vec nat;
+};
+
+type LanguageEvaluationDataPoint = record {
+    prompt: text;
+    response: opt text;
+    valid: bool;
+    error: bool;
+    correct_answer: text;
+};
+
+type LanguageEvaluationMetrics = record {
+    overall_accuracy: opt float32;
+    accuracy_on_valid_responses: opt float32;
+    format_error_rate: opt float32;
+    n: nat32;
+    error_count: nat32;
+    invalid_responses: nat32;
+    correct_responses: nat32;
+    incorrect_responses: nat32;
+};
+
+type LanguageEvaluationResult = record {
+    language_model_evaluation_id: nat;
+    timestamp: nat64;
+    languages: vec text;
+    data_points: vec LanguageEvaluationDataPoint;
+    prompt_templates: vec record {text; text};
+    metrics: LanguageEvaluationMetrics;
+    metrics_per_language: vec record {text; LanguageEvaluationMetrics};
+    max_queries: nat64;
 };
 
 service : () -> {
@@ -276,4 +322,6 @@ service : () -> {
 
     "set_config": (text, text) -> ();
     "get_config": (text) -> (variant { Ok: text; Err: GenericError }) query;
+
+    "llm_evaluate_languages": (model_id : nat, languages : vec text, max_queries : nat64, seed : nat32) -> (variant { Ok : LanguageEvaluationResult; Err : text });
 }

--- a/src/FAI3_backend/src/data_management.rs
+++ b/src/FAI3_backend/src/data_management.rs
@@ -2,18 +2,12 @@ use crate::{
     check_cycles_before_action, is_owner, DataPoint, MODELS, NEXT_DATA_POINT_ID
 };
 
-use crate::types::{get_classifier_model_data, ModelDetails};
+use crate::types::{get_classifier_model_data, UpdatedDetails};
 use crate::types::{ModelType, KeyValuePair};
 use std::collections::HashMap;
-use candid::{CandidType, Deserialize as CandidDeserialize, Principal};
+use candid::Principal;
 
 use crate::model::update_model;
-
-#[derive(CandidType, CandidDeserialize, Clone, Debug)]
-pub(crate) struct UpdatedDetails {
-    name: String,
-    details: ModelDetails,
-}
 
 #[ic_cdk::update]
 /// Adds a dataset to an specified model.

--- a/src/FAI3_backend/src/data_management.rs
+++ b/src/FAI3_backend/src/data_management.rs
@@ -3,8 +3,6 @@ use crate::{
 };
 
 use crate::types::{get_classifier_model_data, ModelDetails};
-use candid::Principal;
-
 use crate::types::{ModelType, KeyValuePair};
 use std::collections::HashMap;
 use candid::{CandidType, Deserialize as CandidDeserialize, Principal};

--- a/src/FAI3_backend/src/errors.rs
+++ b/src/FAI3_backend/src/errors.rs
@@ -24,7 +24,8 @@ impl GenericError {
     // Specific errors within categories
     pub const EMPTY_INPUT: u16 = 101;
     pub const INVALID_FORMAT: u16 = 102;
-
+    pub const INVALID_ARGUMENT: u16 = 103;
+    
     pub const RESOURCE_ERROR: u16 = 300;
     pub const NOT_FOUND: u16 = 301;
     pub const ALREADY_EXISTS: u16 = 302;

--- a/src/FAI3_backend/src/hugging_face.rs
+++ b/src/FAI3_backend/src/hugging_face.rs
@@ -13,6 +13,7 @@ const HUGGING_FACE_ENDPOINT: &str = "https://api-inference.huggingface.co/models
 
 #[derive(Serialize, Deserialize, Clone)]
 pub struct HuggingFaceRequestParameters {
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub stop: Option<Vec<char>>,
     pub max_new_tokens: Option<u32>,
     pub temperature: Option<f32>,

--- a/src/FAI3_backend/src/lib.rs
+++ b/src/FAI3_backend/src/lib.rs
@@ -7,6 +7,7 @@ mod metrics_calculation;
 mod hugging_face;
 pub mod context_association_test;
 pub mod llm_fairness;
+pub mod llm_language_evaluations;
 mod utils;
 pub mod errors;
 mod config_management;
@@ -75,10 +76,18 @@ thread_local! {
         ).unwrap()
     );
 
+
     static CONFIGURATION: RefCell<StableBTreeMap<String, String, VirtualMemory<DefaultMemoryImpl>>> = RefCell::new(
         StableBTreeMap::init(
             MEMORY_MANAGER.with(|m| m.borrow().get(MemoryId::new(6)))
         )
+    );
+
+    static NEXT_LLM_LANGUAGE_EVALUATION_ID: RefCell<Cell<u128, VirtualMemory<DefaultMemoryImpl>>> = RefCell::new(
+        Cell::init(
+            MEMORY_MANAGER.with(|m| m.borrow().get(MemoryId::new(7))),
+            1
+        ).unwrap()
     );
 }
 

--- a/src/FAI3_backend/src/llm_language_evaluations.rs
+++ b/src/FAI3_backend/src/llm_language_evaluations.rs
@@ -1,0 +1,332 @@
+use ic_cdk_macros::*;
+use crate::hugging_face::{call_hugging_face, HuggingFaceRequestParameters};
+use crate::types::{LanguageEvaluationResult, LanguageEvaluationMetrics, ModelType, LLMModelData, LanguageEvaluationDataPoint, get_llm_model_data};
+use crate::{check_cycles_before_action, NEXT_LLM_LANGUAGE_EVALUATION_ID, get_model_from_memory, only_admin};
+use crate::utils::{is_owner, seeded_vector_shuffle};
+use crate::errors::GenericError;
+use crate::MODELS;
+use serde::{Serialize, Deserialize};
+use std::collections::HashMap;
+use std::collections::HashSet;
+
+const KALEIDOSKOPE_CSV: &str = include_str!("data/kaleidoscope.csv");
+
+const SYSTEM_PROMPT: &str = "You are a helpful assistant who answers multiple-choice questions. For each question,
+output your final answer in JSON format with the following structure: {\"choice\":
+\"The correct option\"}. ONLY output this format exactly. Do
+not include any additional text or explanations outside the JSON structure.";
+
+fn build_prompt(question: &String, options: &Vec<String>, seed: u32) -> String {
+    let mut prompt = String::with_capacity(
+        SYSTEM_PROMPT.len() + 
+        question.len() + 
+        options.iter().map(|s| s.len() + 1).sum::<usize>() + 
+        4  // For extra newlines
+    );
+    
+    prompt.push_str(SYSTEM_PROMPT);
+    prompt.push_str("\n\n");
+    prompt.push_str(question);
+    prompt.push_str("\n");
+
+    // Create and shuffle option indices
+    let mut option_indices: Vec<usize> = (0..options.len()).collect();
+    option_indices = seeded_vector_shuffle(option_indices, seed);
+
+    // Add shuffled options
+    for &idx in &option_indices {
+        prompt.push_str(&options[idx]);
+        prompt.push_str("\n");
+    }
+    
+    prompt
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct LanguageEvaluationAnswer {
+    pub choice: String,
+}
+
+async fn run_evaluate_languages(model_data: &LLMModelData, languages: &Vec<String>, seed: u32, max_queries: usize) -> Result<LanguageEvaluationResult, String> {
+    let mut data_points: Vec<LanguageEvaluationDataPoint> = Vec::new();
+
+    let mut metrics = HashMap::<String, LanguageEvaluationMetrics>::new(); 
+    let mut overall_metrics = LanguageEvaluationMetrics::new();
+
+    // Create a metrics object for every separated language
+    for lang in languages {
+        metrics.insert(lang.clone(), LanguageEvaluationMetrics::new());
+    }
+    
+    let hf_parameters = HuggingFaceRequestParameters {
+        max_new_tokens: None,
+        stop: None,
+        temperature: Some(0.3),
+        decoder_input_details: Some(false),
+        details: Some(false),
+        return_full_text: Some(false),
+        seed: Some(seed),
+        do_sample: Some(false),
+    };
+
+    // The number of max_queries is divided among the number of languages
+    // Using integer division
+    let original_max_queries = max_queries;
+    let max_queries = max_queries / languages.len();
+    
+    for lang in languages {
+        let mut queries : usize = 0;
+        ic_cdk::println!("Processing `{}` language", lang);
+        let mut rdr = csv::ReaderBuilder::new()
+            .from_reader(KALEIDOSKOPE_CSV.as_bytes());
+        for result in rdr.deserialize::<HashMap<String, String>>() {
+            let result = result.map_err(|e| e.to_string())?;
+
+            let language: &String = result.get("language")
+                .expect("It should be able to get the language field.");
+            
+            if language != lang {
+                // Only process records for current language
+                continue;
+            }
+
+            ic_cdk::println!("Language: {}", language);
+            
+            let question: &String = result.get("question")
+                .expect("It should be able to get the question field.");
+            let answer: usize = result.get("answer")
+                .and_then(|ans| ans.parse::<usize>().ok())
+                .expect("Answer field should be a valid usize index");
+            let options: Vec<String> = result.get("options")
+                .map(|opt_str| {
+                    ic_cdk::println!("{}", &opt_str);
+                    // Split by space and clean up quotes from each element
+                    opt_str.trim_matches(|c| c == '[' || c == ']')
+                        .split('\'')
+                        .filter(|s| !s.trim().is_empty() && s.trim() != " ")
+                        .map(|s| s.trim().to_string())
+                        .collect()
+                })
+                .expect("It should be able to parse the options field.");
+            let text_answer: String = options.get(answer)
+                .expect("Answer should exist in the options vector")
+                .to_string();
+            ic_cdk::println!("Valid answer: {}", text_answer);
+
+            let lang_metrics: &mut LanguageEvaluationMetrics = metrics.get_mut(language).expect("Value for language should exist");
+
+            let prompt: String = build_prompt(&question, &options, seed * (queries as u32));
+            
+            let res = call_hugging_face(prompt.clone(), model_data.hugging_face_url.clone(), seed, Some(hf_parameters.clone())).await;
+
+            let trimmed_response = match res {
+                Ok(response) => response.trim().to_string(),
+                Err(e) => {
+                    ic_cdk::println!("Error calling Hugging Face API: {}", e);
+
+                    overall_metrics.add_error();
+                    lang_metrics.add_error();
+
+                    data_points.push(LanguageEvaluationDataPoint {
+                        prompt: prompt.clone(),
+                        response: None,
+                        valid: false,
+                        error: true,
+                        correct_answer: text_answer.clone(),
+                    });
+                    
+                    queries += 1;
+                    if max_queries > 0 && queries >= max_queries {
+                        break;
+                    }
+                    
+                    continue; // Skip this iteration and continue with the next question
+                }
+            };
+
+            ic_cdk::println!("Trimmed response: {}", &trimmed_response);
+
+            let evaluation_answer = match serde_json::from_str::<LanguageEvaluationAnswer>(&trimmed_response) {
+                Ok(json) => {
+                    ic_cdk::println!("Parsed JSON response: {:?}", &json);
+                    json
+                },
+                Err(e) => {
+                    ic_cdk::println!("Failed to parse JSON: {}. Skipping to next row.", e);
+                    overall_metrics.add_invalid();
+                    lang_metrics.add_invalid();
+
+                    data_points.push(LanguageEvaluationDataPoint {
+                        prompt: prompt.clone(),
+                        response: None,
+                        valid: false,
+                        error: false,
+                        correct_answer: text_answer.clone(),
+                    });
+                    
+                    queries += 1;
+                    if max_queries > 0 && queries >= max_queries {
+                        break;
+                    }
+                    continue;
+                }
+            };
+
+            let llm_answer = evaluation_answer.choice.trim();
+
+            data_points.push(LanguageEvaluationDataPoint {
+                prompt: prompt.clone(),
+                response: Some(llm_answer.to_string()),
+                valid: false,
+                error: false,
+                correct_answer: text_answer.clone(),
+            });
+
+            if llm_answer.to_lowercase() == text_answer.trim().to_lowercase() {
+                overall_metrics.add_correct();
+                lang_metrics.add_correct();
+            } else {
+                // Check if it belongs to any of the options, otherwise it's classified as invalid
+                let mut belongs_to_an_option = false;
+                for option in &options {
+                    if llm_answer.to_lowercase() == option.trim().to_lowercase() {
+                        belongs_to_an_option = true;
+                        break;
+                    }
+                }
+                if belongs_to_an_option {
+                    overall_metrics.add_incorrect();
+                    lang_metrics.add_incorrect();
+                } else {
+                    overall_metrics.add_invalid();
+                    lang_metrics.add_invalid();
+                }
+            }
+
+            queries += 1;
+            if max_queries > 0 && queries >= max_queries {
+                break;
+            }
+        }
+    }
+
+    overall_metrics.calculate_rates();
+    for lang_metrics in metrics.values_mut() {
+        lang_metrics.calculate_rates();
+    }
+
+    // Done in this way so the result order is deterministic
+    let mut metrics_per_language = Vec::<(String, LanguageEvaluationMetrics)>::new();
+    for lang in languages {
+        metrics_per_language.push((lang.clone(), metrics.get(lang).unwrap().clone()));
+    }
+    
+    let result = NEXT_LLM_LANGUAGE_EVALUATION_ID.with( |id| {
+        let current_id = *id.borrow().get();
+        
+        let evaluation = LanguageEvaluationResult {
+            language_model_evaluation_id: current_id,
+            timestamp: ic_cdk::api::time(),
+            languages: languages.clone(),
+            prompt_templates: vec![("overall".to_string(), SYSTEM_PROMPT.to_string())],
+            data_points,
+            metrics: overall_metrics,
+            metrics_per_language,
+            max_queries: original_max_queries,
+        };
+
+        id.borrow_mut().set(current_id + 1).unwrap();
+
+        evaluation
+    });
+
+    return Ok(result);
+}
+
+/// Evaluates languages for a LLM. It returns the LanguageEvaluationResult,
+/// and it also saves the result into the model data.
+#[update]
+pub async fn llm_evaluate_languages(model_id: u128, languages: Vec<String>, max_queries: usize, seed: u32) -> Result<LanguageEvaluationResult, GenericError> {
+    only_admin();
+    check_cycles_before_action();
+
+    if languages.len() == 0 {
+        return Err(GenericError::new(GenericError::INVALID_ARGUMENT, "You should select at least one language."));
+    }
+    let valid_values: HashSet<&str> = ["ar", "bn", "de", "en", "es", "fa", "fr", "hi", "hr", "hu", "lt", "nl", "pt", "ru", "sr", "uk"].into_iter().collect();
+    let all_valid = languages.iter().all(|x| valid_values.contains(x.as_str()));
+    if !all_valid {
+        return Err(GenericError::new(GenericError::INVALID_ARGUMENT, "An invalid language was selected."));
+    }
+    
+    let caller = ic_cdk::api::caller();
+
+    ic_cdk::println!("Calling llm_evaluate_languages for model {}", model_id);
+
+    let model = get_model_from_memory(model_id);
+    if let Err(err) = model {
+        return Err(err);
+    }
+    let model = model.unwrap();
+    is_owner(&model, caller);
+
+    if let ModelType::LLM(model_type_data) = model.model_type {
+        let result = run_evaluate_languages(&model_type_data, &languages, seed, max_queries).await;
+        
+        return match result {
+            Ok(language_evaluation_result) => {
+                MODELS.with(|models| {
+                    let mut models = models.borrow_mut();
+                    let mut model = models.get(&model_id).expect("Model not found");
+
+                    let mut model_data = get_llm_model_data(&model);
+                    
+                    model_data.language_evaluations.push(language_evaluation_result.clone());
+                    
+                    model.model_type = ModelType::LLM(model_data);
+                    models.insert(model_id, model);
+                });
+
+                Ok(language_evaluation_result)
+            },
+            Err(err_message) => {
+                Err(GenericError::new(GenericError::GENERIC_SYSTEM_FAILURE, err_message))
+            }
+        };
+    } else {
+        return Err(GenericError::new(GenericError::INVALID_MODEL_TYPE, "Model should be a LLM"));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_build_prompt() {
+        // Test inputs
+        let question = String::from("What is the capital of France?");
+        let options = vec![
+            String::from("A) Paris"),
+            String::from("B) London"),
+            String::from("C) Berlin"),
+            String::from("D) Madrid")
+        ];
+        let seed = 42;
+
+        // Build the prompt
+        let result = build_prompt(&question, &options, seed);
+
+        // Verify the prompt contains all required elements
+        assert!(result.contains(SYSTEM_PROMPT));
+        assert!(result.contains("What is the capital of France?"));
+        
+        // Verify all options are present
+        for option in options.iter() {
+            assert!(result.contains(option));
+        }
+
+        // Verify basic structure (contains newlines between sections)
+        assert!(result.contains("\n\n"));
+    }
+}

--- a/src/FAI3_backend/src/model.rs
+++ b/src/FAI3_backend/src/model.rs
@@ -103,6 +103,7 @@ pub fn add_llm_model(model_name: String, hugging_face_url: String, model_details
                         hugging_face_url,
                         evaluations: Vec::new(),
                         average_fairness_metrics: None,
+                        language_evaluations: Vec::new(),
                     }),
                     cached_thresholds: None,
                     cached_selections: None,

--- a/src/FAI3_backend/src/types.rs
+++ b/src/FAI3_backend/src/types.rs
@@ -344,6 +344,12 @@ pub struct ModelDetails {
 }
 
 #[derive(CandidType, CandidDeserialize, Clone, Debug)]
+pub struct UpdatedDetails {
+    pub name: String,
+    pub details: ModelDetails,
+}
+
+#[derive(CandidType, CandidDeserialize, Clone, Debug)]
 pub struct ModelDetailsHistory {
     pub(crate) name: String,
     pub(crate) details: ModelDetails,

--- a/src/FAI3_backend/tests/common/mod.rs
+++ b/src/FAI3_backend/tests/common/mod.rs
@@ -10,7 +10,7 @@ use pocket_ic::{
     },
 };
 use FAI3_backend::types::{
-    Model, ModelDetails, KeyValuePair, PrivilegedIndex,
+    Model, ModelDetails, UpdatedDetails, KeyValuePair, PrivilegedIndex,
 };
 
 // 2T cycles
@@ -172,7 +172,15 @@ pub fn add_dataset(
     model_id: u128, features: Vec<Vec<f64>>, labels: Vec<bool>,
     predictions: Vec<bool>, privileged: Vec<KeyValuePair>, selection_labels: Vec<String>) -> Result<(), candid::Error> {
 
-    let encoded_args = encode_args((model_id, features, labels, predictions, privileged, selection_labels)).unwrap();
+    let encoded_args = encode_args((model_id, features, labels, predictions, privileged, selection_labels, UpdatedDetails {
+        name: "new name".to_string(),
+        details: ModelDetails {
+            description: "...".to_string(),
+            framework: "...".to_string(),
+            objective: "...".to_string(),
+            url: "...".to_string(),
+        },
+    })).unwrap();
     // Testing add_classifier_model.
     let create_model_reply = pic.update_call(
         canister_id,

--- a/src/FAI3_backend/tests/common/mod.rs
+++ b/src/FAI3_backend/tests/common/mod.rs
@@ -4,6 +4,7 @@ use ic_management_canister_types::CanisterId;
 use pocket_ic::{
     PocketIc,
     common::rest::{
+        RawMessageId,
         CanisterHttpReply, CanisterHttpResponse,
         MockCanisterHttpResponse, CanisterHttpRequest,
     },
@@ -280,4 +281,23 @@ pub fn mock_correct_hugging_face_response_body(generated_text: &str) -> String {
             }
         }
     ]).to_string()
+}
+
+pub fn wait_for_mocks_strings(pic: &PocketIc, call_id: RawMessageId, mocked_texts: &Vec<String>) -> Vec<u8> {
+    // Mocking HTTP responses based on returned_texts
+    for text in mocked_texts {
+        wait_for_http_request(&pic);
+        let canister_http_requests = pic.get_canister_http();
+        if canister_http_requests.is_empty() {
+            break;
+        }
+        
+        let canister_http_request = &canister_http_requests[0];
+        let mock_hf_response_body = mock_correct_hugging_face_response_body(text.as_str());
+        
+        let mock_canister_http_response = mock_http_response(canister_http_request, mock_hf_response_body);
+        pic.mock_canister_http_response(mock_canister_http_response);
+    }
+
+    return pic.await_call(call_id).unwrap();
 }

--- a/src/FAI3_backend/tests/llm_language_evaluations.rs
+++ b/src/FAI3_backend/tests/llm_language_evaluations.rs
@@ -3,7 +3,7 @@ use FAI3_backend::types::{get_llm_model_data, LanguageEvaluationResult, Language
 use FAI3_backend::errors::GenericError;
 mod common;
 use common::{
-    create_pic, create_llm_model, get_model,
+    create_pic, create_llm_model, get_model, add_hf_api_key,
     wait_for_http_request, mock_http_response, mock_correct_hugging_face_response_body, wait_for_mocks_strings,
 };
 use FAI3_backend::llm_language_evaluations::LanguageEvaluationAnswer;
@@ -18,6 +18,7 @@ fn json_answer(answer: &str) -> String {
 fn test_language_evaluations_with_multiple_languages() {
     let (pic, canister_id) = create_pic();
     let model_id: u128 = create_llm_model(&pic, canister_id, "Test Model".to_string());
+    add_hf_api_key(&pic, canister_id, model_id);
     let seed: u32 = 0;
     let max_queries: usize = 10;
     
@@ -106,6 +107,7 @@ fn test_language_evaluations_with_multiple_languages() {
 fn test_language_evaluations_perfect_score() {
     let (pic, canister_id) = create_pic();
     let model_id: u128 = create_llm_model(&pic, canister_id, "Test Model".to_string());
+    add_hf_api_key(&pic, canister_id, model_id);
     let seed: u32 = 0;
     let max_queries: usize = 5;
     
@@ -176,6 +178,7 @@ fn test_language_evaluations_perfect_score() {
 fn test_language_evaluations_non_perfect_score() {
     let (pic, canister_id) = create_pic();
     let model_id: u128 = create_llm_model(&pic, canister_id, "Test Model".to_string());
+    add_hf_api_key(&pic, canister_id, model_id);
     let seed: u32 = 0;
     let max_queries: usize = 5;
     
@@ -246,6 +249,7 @@ fn test_language_evaluations_non_perfect_score() {
 fn test_language_evaluations_with_invalid_answers() {
     let (pic, canister_id) = create_pic();
     let model_id: u128 = create_llm_model(&pic, canister_id, "Test Model".to_string());
+    add_hf_api_key(&pic, canister_id, model_id);
     let seed: u32 = 0;
     let max_queries: usize = 5;
     
@@ -315,6 +319,7 @@ fn test_language_evaluations_with_invalid_answers() {
 fn test_hugging_face_invalid_json_responses() {
     let (pic, canister_id) = create_pic();
     let model_id: u128 = create_llm_model(&pic, canister_id, "Test Model".to_string());
+    add_hf_api_key(&pic, canister_id, model_id);
     let seed: u32 = 1;
     let max_queries: usize = 2;
     
@@ -372,6 +377,7 @@ fn test_hugging_face_invalid_json_responses() {
 fn test_language_evaluations_with_invalid_json() {
     let (pic, canister_id) = create_pic();
     let model_id: u128 = create_llm_model(&pic, canister_id, "Test Model".to_string());
+    add_hf_api_key(&pic, canister_id, model_id);
     let seed: u32 = 1;
     let max_queries: usize = 2;
     
@@ -432,6 +438,7 @@ fn test_language_evaluations_with_invalid_json() {
 fn test_language_evaluations_with_unknown_languages() {
     let (pic, canister_id) = create_pic();
     let model_id: u128 = create_llm_model(&pic, canister_id, "Test Model".to_string());
+    add_hf_api_key(&pic, canister_id, model_id);
     let seed: u32 = 1;
     let max_queries: usize = 1;
     
@@ -462,6 +469,7 @@ fn test_language_evaluations_with_unknown_languages() {
 fn test_language_evaluations_with_0_languages_should_error() {
     let (pic, canister_id) = create_pic();
     let model_id: u128 = create_llm_model(&pic, canister_id, "Test Model".to_string());
+    add_hf_api_key(&pic, canister_id, model_id);
     let seed: u32 = 1;
     let max_queries: usize = 1;
     

--- a/src/FAI3_backend/tests/llm_language_evaluations.rs
+++ b/src/FAI3_backend/tests/llm_language_evaluations.rs
@@ -1,0 +1,489 @@
+use candid::{Principal, decode_one, encode_args};
+use FAI3_backend::types::{get_llm_model_data, LanguageEvaluationResult, LanguageEvaluationMetrics};
+use FAI3_backend::errors::GenericError;
+mod common;
+use common::{
+    create_pic, create_llm_model, get_model,
+    wait_for_http_request, mock_http_response, mock_correct_hugging_face_response_body, wait_for_mocks_strings,
+};
+use FAI3_backend::llm_language_evaluations::LanguageEvaluationAnswer;
+
+fn json_answer(answer: &str) -> String {
+    serde_json::to_string(&LanguageEvaluationAnswer {
+        choice: answer.to_string()
+    }).unwrap()
+}
+
+#[test]
+fn test_language_evaluations_with_multiple_languages() {
+    let (pic, canister_id) = create_pic();
+    let model_id: u128 = create_llm_model(&pic, canister_id, "Test Model".to_string());
+    let seed: u32 = 0;
+    let max_queries: usize = 10;
+    
+   // Calculate average metrics
+    let languages = vec!["es", "en"];
+    // Submit an update call to the test canister to calculate all LLM metrics
+    let encoded_args = encode_args((model_id, languages, max_queries, seed)).unwrap();
+    let call_id = pic.submit_call(
+        canister_id,
+        Principal::anonymous(),
+        "llm_evaluate_languages",
+        encoded_args,
+    ).expect("llm_evaluate_languages call should be submitted.");
+
+    let mocked_texts = vec![
+        json_answer("La Respuesta A y B, son Correctas"),
+        json_answer("8"), // incorrect answer
+        json_answer("La Respuesta A y B, son Correctas."),
+        json_answer("Todos los grados de yododeficiencia (leve, moderada o severa), pueden potencialmente causar daño neurológico en el feto"),
+        json_answer("La Respuesta C y D, son Correctas"),
+        json_answer("Hans Peters"),
+        json_answer("Protein"), // incorrect answer
+        json_answer("Anther is kidney shaped"),
+        json_answer("i and ii"),
+        json_answer("In pectoral girdle"),
+    ];
+    
+    let reply = wait_for_mocks_strings(&pic, call_id, &mocked_texts);
+    let result: Result<LanguageEvaluationResult, GenericError> = decode_one(&reply).expect("Failed to decode llm_evaluate_languages reply.");
+
+    assert!(result.is_ok(), "Result should be ok");
+
+    let result: LanguageEvaluationResult = result.unwrap();
+
+    fn assert_overall_metrics(metrics: &LanguageEvaluationMetrics) {
+        assert_eq!(metrics.n, 10);
+        assert_eq!(metrics.correct_responses, 8);
+        assert_eq!(metrics.incorrect_responses, 2);
+        assert_eq!(metrics.error_count, 0);
+        assert_eq!(metrics.invalid_responses, 0);
+        
+        assert_eq!(metrics.overall_accuracy, Some(0.8));
+        assert_eq!(metrics.accuracy_on_valid_responses, Some(0.8));
+    }
+
+    fn assert_language_metrics(metrics: &LanguageEvaluationMetrics) {
+        assert_eq!(metrics.n, 5);
+        assert_eq!(metrics.correct_responses, 4);
+        assert_eq!(metrics.incorrect_responses, 1);
+        assert_eq!(metrics.error_count, 0);
+        assert_eq!(metrics.invalid_responses, 0);
+        
+        assert_eq!(metrics.overall_accuracy, Some(0.8));
+        assert_eq!(metrics.accuracy_on_valid_responses, Some(0.8));
+    }
+
+    fn assert_score_result(result: &LanguageEvaluationResult) {
+        assert_eq!(result.data_points.len(), 10);
+        assert_eq!(result.language_model_evaluation_id, 1);
+        assert_eq!(result.max_queries, 10);
+        assert_eq!(result.languages, vec!["es", "en"]);
+        assert_overall_metrics(&result.metrics);
+        
+        // check metrics for en language
+        assert_eq!(result.metrics_per_language.len(), 2);
+        let (es_label, es_metrics) = result.metrics_per_language.get(0).unwrap();
+        assert_eq!("es", es_label);
+        assert_language_metrics(&es_metrics);
+        let (en_label, en_metrics) = result.metrics_per_language.get(1).unwrap();
+        assert_eq!("en", en_label);
+        assert_language_metrics(&en_metrics);
+    }
+
+    assert_score_result(&result);
+    
+    // checking it was saved correctly
+    let model = get_model(&pic, canister_id, model_id);
+    let llm_model_data = get_llm_model_data(&model);
+
+    assert_eq!(llm_model_data.language_evaluations.len(), 1);
+    let evaluation = llm_model_data.language_evaluations.get(0).unwrap();
+    assert_score_result(&evaluation);
+}
+
+#[test]
+fn test_language_evaluations_perfect_score() {
+    let (pic, canister_id) = create_pic();
+    let model_id: u128 = create_llm_model(&pic, canister_id, "Test Model".to_string());
+    let seed: u32 = 0;
+    let max_queries: usize = 5;
+    
+   // Calculate average metrics
+    let languages = vec!["en"];
+    // Submit an update call to the test canister to calculate all LLM metrics
+    let encoded_args = encode_args((model_id, languages, max_queries, seed)).unwrap();
+    let call_id = pic.submit_call(
+        canister_id,
+        Principal::anonymous(),
+        "llm_evaluate_languages",
+        encoded_args,
+    ).expect("llm_evaluate_languages call should be submitted.");
+
+    let mocked_texts = vec![
+        json_answer("Hans Peters"),
+        json_answer("Chitin"),
+        json_answer("Anther is kidney shaped"),
+        json_answer("i and ii"),
+        json_answer("In pectoral girdle"),
+        
+    ];
+    
+    let reply = wait_for_mocks_strings(&pic, call_id, &mocked_texts);
+    let result: Result<LanguageEvaluationResult, GenericError> = decode_one(&reply).expect("Failed to decode llm_evaluate_languages reply.");
+
+    assert!(result.is_ok(), "Result should be ok");
+
+    let result: LanguageEvaluationResult = result.unwrap();
+
+    fn assert_perfect_score_metrics(metrics: &LanguageEvaluationMetrics) {
+        assert_eq!(metrics.n, 5);
+        assert_eq!(metrics.correct_responses, 5);
+        assert_eq!(metrics.incorrect_responses, 0);
+        assert_eq!(metrics.error_count, 0);
+        assert_eq!(metrics.invalid_responses, 0);
+        
+        assert_eq!(metrics.overall_accuracy, Some(1.0));
+        assert_eq!(metrics.accuracy_on_valid_responses, Some(1.0));
+    }
+
+    fn assert_perfect_score_result(result: &LanguageEvaluationResult) {
+        assert_eq!(result.data_points.len(), 5);
+        assert_eq!(result.language_model_evaluation_id, 1);
+        assert_eq!(result.max_queries, 5);
+        assert_eq!(result.languages, vec!["en"]);
+        assert_perfect_score_metrics(&result.metrics);
+        
+        // check metrics for en language
+        assert_eq!(result.metrics_per_language.len(), 1);
+        let (en_label, en_metrics) = result.metrics_per_language.get(0).unwrap();
+        assert_eq!("en", en_label);
+        assert_perfect_score_metrics(&en_metrics);
+    }
+
+    assert_perfect_score_result(&result);
+    
+    // checking it was saved correctly
+    let model = get_model(&pic, canister_id, model_id);
+    let llm_model_data = get_llm_model_data(&model);
+
+    assert_eq!(llm_model_data.language_evaluations.len(), 1);
+    let evaluation = llm_model_data.language_evaluations.get(0).unwrap();
+    assert_perfect_score_result(&evaluation);
+}
+
+#[test]
+fn test_language_evaluations_non_perfect_score() {
+    let (pic, canister_id) = create_pic();
+    let model_id: u128 = create_llm_model(&pic, canister_id, "Test Model".to_string());
+    let seed: u32 = 0;
+    let max_queries: usize = 5;
+    
+   // Calculate average metrics
+    let languages = vec!["en"];
+    // Submit an update call to the test canister to calculate all LLM metrics
+    let encoded_args = encode_args((model_id, languages, max_queries, seed)).unwrap();
+    let call_id = pic.submit_call(
+        canister_id,
+        Principal::anonymous(),
+        "llm_evaluate_languages",
+        encoded_args,
+    ).expect("llm_evaluate_languages call should be submitted.");
+
+    let mocked_texts = vec![
+        json_answer("Hans Peters"),
+        json_answer("Protein"), // incorrect answer
+        json_answer("Anther is kidney shaped"),
+        json_answer("i, ii and iii"), // incorrect answer
+        json_answer("In pectoral girdle"),
+        
+    ];
+    
+    let reply = wait_for_mocks_strings(&pic, call_id, &mocked_texts);
+    let result: Result<LanguageEvaluationResult, GenericError> = decode_one(&reply).expect("Failed to decode llm_evaluate_languages reply.");
+
+    assert!(result.is_ok(), "Result should be ok");
+
+    let result: LanguageEvaluationResult = result.unwrap();
+
+    fn assert_non_perfect_score_metrics(metrics: &LanguageEvaluationMetrics) {
+        assert_eq!(metrics.n, 5);
+        assert_eq!(metrics.correct_responses, 3);
+        assert_eq!(metrics.incorrect_responses, 2);
+        assert_eq!(metrics.error_count, 0);
+        assert_eq!(metrics.invalid_responses, 0);
+        
+        assert_eq!(metrics.overall_accuracy, Some(0.6));
+        assert_eq!(metrics.accuracy_on_valid_responses, Some(0.6));
+    }
+
+    fn assert_non_perfect_score_result(result: &LanguageEvaluationResult) {
+        assert_eq!(result.data_points.len(), 5);
+        assert_eq!(result.language_model_evaluation_id, 1);
+        assert_eq!(result.max_queries, 5);
+        assert_eq!(result.languages, vec!["en"]);
+        assert_non_perfect_score_metrics(&result.metrics);
+        
+        // check metrics for en language
+        assert_eq!(result.metrics_per_language.len(), 1);
+        let (en_label, en_metrics) = result.metrics_per_language.get(0).unwrap();
+        assert_eq!("en", en_label);
+        assert_non_perfect_score_metrics(&en_metrics);
+    }
+
+    assert_non_perfect_score_result(&result);
+    
+    // checking it was saved correctly
+    let model = get_model(&pic, canister_id, model_id);
+    let llm_model_data = get_llm_model_data(&model);
+
+    assert_eq!(llm_model_data.language_evaluations.len(), 1);
+    let evaluation = llm_model_data.language_evaluations.get(0).unwrap();
+    assert_non_perfect_score_result(&evaluation);
+}
+
+#[test]
+fn test_language_evaluations_with_invalid_answers() {
+    let (pic, canister_id) = create_pic();
+    let model_id: u128 = create_llm_model(&pic, canister_id, "Test Model".to_string());
+    let seed: u32 = 0;
+    let max_queries: usize = 5;
+    
+   // Calculate average metrics
+    let languages = vec!["en"];
+    // Submit an update call to the test canister to calculate all LLM metrics
+    let encoded_args = encode_args((model_id, languages, max_queries, seed)).unwrap();
+    let call_id = pic.submit_call(
+        canister_id,
+        Principal::anonymous(),
+        "llm_evaluate_languages",
+        encoded_args,
+    ).expect("llm_evaluate_languages call should be submitted.");
+
+    let mocked_texts = vec![
+        json_answer("invalid answer"),
+        json_answer("invalid answer"),
+        json_answer("invalid answer"),
+        json_answer("invalid answer"),
+        json_answer("invalid answer"),        
+    ];
+    
+    let reply = wait_for_mocks_strings(&pic, call_id, &mocked_texts);
+    let result: Result<LanguageEvaluationResult, GenericError> = decode_one(&reply).expect("Failed to decode llm_evaluate_languages reply.");
+
+    assert!(result.is_ok(), "Result should be ok");
+
+    let result: LanguageEvaluationResult = result.unwrap();
+
+    fn assert_invalid_score_metrics(metrics: &LanguageEvaluationMetrics) {
+        assert_eq!(metrics.n, 5);
+        assert_eq!(metrics.correct_responses, 0);
+        assert_eq!(metrics.incorrect_responses, 0);
+        assert_eq!(metrics.error_count, 0);
+        assert_eq!(metrics.invalid_responses, 5);
+        
+        assert_eq!(metrics.overall_accuracy, Some(0.0));
+        assert_eq!(metrics.accuracy_on_valid_responses, None);
+    }
+
+    fn assert_invalid_score_result(result: &LanguageEvaluationResult) {
+        assert_eq!(result.data_points.len(), 5);
+        assert_eq!(result.language_model_evaluation_id, 1);
+        assert_eq!(result.max_queries, 5);
+        assert_eq!(result.languages, vec!["en"]);
+        assert_invalid_score_metrics(&result.metrics);
+        
+        // check metrics for en language
+        assert_eq!(result.metrics_per_language.len(), 1);
+        let (en_label, en_metrics) = result.metrics_per_language.get(0).unwrap();
+        assert_eq!("en", en_label);
+        assert_invalid_score_metrics(&en_metrics);
+    }
+
+    assert_invalid_score_result(&result);
+    
+    // checking it was saved correctly
+    let model = get_model(&pic, canister_id, model_id);
+    let llm_model_data = get_llm_model_data(&model);
+
+    assert_eq!(llm_model_data.language_evaluations.len(), 1);
+    let evaluation = llm_model_data.language_evaluations.get(0).unwrap();
+    assert_invalid_score_result(&evaluation);
+}
+
+#[test]
+fn test_hugging_face_invalid_json_responses() {
+    let (pic, canister_id) = create_pic();
+    let model_id: u128 = create_llm_model(&pic, canister_id, "Test Model".to_string());
+    let seed: u32 = 1;
+    let max_queries: usize = 2;
+    
+   // Calculate average metrics
+    let languages = vec!["en"];
+    // Submit an update call to the test canister to calculate all LLM metrics
+    let encoded_args = encode_args((model_id, languages, max_queries, seed)).unwrap();
+    let call_id = pic.submit_call(
+        canister_id,
+        Principal::anonymous(),
+        "llm_evaluate_languages",
+        encoded_args,
+    ).expect("llm_evaluate_languages call should be submitted.");
+
+    for _ in 0..2 {
+        wait_for_http_request(&pic);
+        let canister_http_requests = pic.get_canister_http();
+        
+        let canister_http_request = &canister_http_requests[0];
+
+        let hf_response = "invalid hf response";        
+        let mock_canister_http_response = mock_http_response(canister_http_request, hf_response);
+        pic.mock_canister_http_response(mock_canister_http_response);
+    }
+
+    let reply = pic.await_call(call_id).unwrap();
+    
+    let result: Result<LanguageEvaluationResult, GenericError> = decode_one(&reply).expect("Failed to decode llm_evaluate_languages reply.");
+    assert!(result.is_ok(), "Result is ok");
+    let result: LanguageEvaluationResult = result.unwrap();
+
+    let metrics = result.metrics;
+    assert_eq!(metrics.n, 2);
+    assert_eq!(metrics.correct_responses, 0);
+    assert_eq!(metrics.incorrect_responses, 0);
+    assert_eq!(metrics.error_count, 2);
+    assert_eq!(metrics.invalid_responses, 0);
+
+    assert_eq!(metrics.overall_accuracy, None);
+    assert_eq!(metrics.accuracy_on_valid_responses, None);
+
+    assert_eq!(result.metrics_per_language.len(), 1);
+    let (_, metrics) = result.metrics_per_language.get(0).unwrap();
+    assert_eq!(metrics.n, 2);
+    assert_eq!(metrics.correct_responses, 0);
+    assert_eq!(metrics.incorrect_responses, 0);
+    assert_eq!(metrics.error_count, 2);
+    assert_eq!(metrics.invalid_responses, 0);
+
+    assert_eq!(metrics.overall_accuracy, None);
+    assert_eq!(metrics.accuracy_on_valid_responses, None);
+}
+
+#[test]
+fn test_language_evaluations_with_invalid_json() {
+    let (pic, canister_id) = create_pic();
+    let model_id: u128 = create_llm_model(&pic, canister_id, "Test Model".to_string());
+    let seed: u32 = 1;
+    let max_queries: usize = 2;
+    
+   // Calculate average metrics
+    let languages = vec!["en"];
+    // Submit an update call to the test canister to calculate all LLM metrics
+    let encoded_args = encode_args((model_id, languages, max_queries, seed)).unwrap();
+    let call_id = pic.submit_call(
+        canister_id,
+        Principal::anonymous(),
+        "llm_evaluate_languages",
+        encoded_args,
+    ).expect("llm_evaluate_languages call should be submitted.");
+
+    for _ in 0..2 {
+        wait_for_http_request(&pic);
+        let canister_http_requests = pic.get_canister_http();
+        
+        let canister_http_request = &canister_http_requests[0];
+
+        // In this case the HF API json response is valid,
+        // but the contents of the LLM response is not valid json
+        let hf_response = mock_correct_hugging_face_response_body("invalid llm json response");
+        
+        let mock_canister_http_response = mock_http_response(canister_http_request, hf_response);
+        pic.mock_canister_http_response(mock_canister_http_response);
+    }
+
+    let reply = pic.await_call(call_id).unwrap();
+    
+    let result: Result<LanguageEvaluationResult, GenericError> = decode_one(&reply).expect("Failed to decode llm_evaluate_languages reply.");
+    assert!(result.is_ok(), "Result is ok");
+    let result: LanguageEvaluationResult = result.unwrap();
+
+    let metrics = result.metrics;
+    assert_eq!(metrics.n, 2);
+    assert_eq!(metrics.correct_responses, 0);
+    assert_eq!(metrics.incorrect_responses, 0);
+    assert_eq!(metrics.error_count, 0);
+    assert_eq!(metrics.invalid_responses, 2);
+    
+    assert_eq!(metrics.overall_accuracy, Some(0.0));
+    assert_eq!(metrics.accuracy_on_valid_responses, None);
+    
+    assert_eq!(result.metrics_per_language.len(), 1);
+    let (_, metrics) = result.metrics_per_language.get(0).unwrap();
+    assert_eq!(metrics.n, 2);
+    assert_eq!(metrics.correct_responses, 0);
+    assert_eq!(metrics.incorrect_responses, 0);
+    assert_eq!(metrics.error_count, 0);
+    assert_eq!(metrics.invalid_responses, 2);
+    
+    assert_eq!(metrics.overall_accuracy, Some(0.0));
+    assert_eq!(metrics.accuracy_on_valid_responses, None);
+}
+
+#[test]
+fn test_language_evaluations_with_unknown_languages() {
+    let (pic, canister_id) = create_pic();
+    let model_id: u128 = create_llm_model(&pic, canister_id, "Test Model".to_string());
+    let seed: u32 = 1;
+    let max_queries: usize = 1;
+    
+   // Calculate average metrics
+    let languages = vec!["en", "unknown"];
+    // Submit an update call to the test canister to calculate all LLM metrics
+    let encoded_args = encode_args((model_id, languages, max_queries, seed)).unwrap();
+    let call_id = pic.submit_call(
+        canister_id,
+        Principal::anonymous(),
+        "llm_evaluate_languages",
+        encoded_args,
+    ).expect("llm_evaluate_languages call should be submitted.");
+
+    let reply = pic.await_call(call_id).unwrap();
+    let result: Result<LanguageEvaluationResult, GenericError> = decode_one(&reply).expect("Failed to decode llm_evaluate_languages reply.");
+
+    assert!(result.is_err(), "Result should be an error");
+
+    let error: GenericError = result.unwrap_err();
+
+    assert_eq!(error.code, GenericError::INVALID_ARGUMENT);
+    assert_eq!(error.message, "An invalid language was selected.");
+
+}
+
+#[test]
+fn test_language_evaluations_with_0_languages_should_error() {
+    let (pic, canister_id) = create_pic();
+    let model_id: u128 = create_llm_model(&pic, canister_id, "Test Model".to_string());
+    let seed: u32 = 1;
+    let max_queries: usize = 1;
+    
+   // Calculate average metrics
+    let languages = Vec::<String>::new();
+    // Submit an update call to the test canister to calculate all LLM metrics
+    let encoded_args = encode_args((model_id, languages, max_queries, seed)).unwrap();
+    let call_id = pic.submit_call(
+        canister_id,
+        Principal::anonymous(),
+        "llm_evaluate_languages",
+        encoded_args,
+    ).expect("llm_evaluate_languages call should be submitted.");
+
+    let reply = pic.await_call(call_id).unwrap();
+    let result: Result<LanguageEvaluationResult, GenericError> = decode_one(&reply).expect("Failed to decode llm_evaluate_languages reply.");
+
+    assert!(result.is_err(), "Result should be an error");
+
+    let error: GenericError = result.unwrap_err();
+
+    assert_eq!(error.code, GenericError::INVALID_ARGUMENT);
+    assert_eq!(error.message, "You should select at least one language.");
+
+}


### PR DESCRIPTION
Adds [Kaleidoscope benchmark](https://arxiv.org/abs/2504.07072) for language evaluation.

How to test:

First, redeploy. If necessary use the reinstall option.

Then run this:

```
# model creation
dfx canister call FAI3_backend add_llm_model '("Mistral-Nemo-Instruct-2407", "mistralai/Mistral-Nemo-Instruct-2407", record {
    description = "Your model description";
    framework = "TensorFlow";
    version = "2.0";
    objective = "Image classification";
    url = "https://example.com/model"
  })'

# language evaluation run
dfx canister call FAI3_backend llm_evaluate_languages '(1, vec { "en"; "es" }, 20, 123456)'
```

The parameters are model_id, languages to eval, max_queries (these are divided equally among the languages to pass. If -, it means it will run the whole dataset) and the seed.

Available languages: "ar", "bn", "de", "en", "es", "fa", "fr", "hi", "hr", "hu", "lt", "nl", "pt", "ru", "sr", "uk"
