### PR TITLE
Inference providers and methods for getting data points

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,6 +14,7 @@ dependencies = [
  "ic-stable-structures",
  "num-traits",
  "pocket-ic",
+ "regex",
  "serde",
  "serde_json",
 ]

--- a/src/FAI3_backend/Cargo.toml
+++ b/src/FAI3_backend/Cargo.toml
@@ -17,6 +17,7 @@ serde_json = "1"
 num-traits = "0.2"
 ic-stable-structures = "0.6.7"
 csv = "1.3.1"
+regex = "1"
 
 [dev-dependencies]
 ic-management-canister-types = "0.3.0"

--- a/src/FAI3_backend/FAI3_backend.did
+++ b/src/FAI3_backend/FAI3_backend.did
@@ -136,6 +136,12 @@ type ModelEvaluationResult = record {
     metrics: Metrics;
     privileged_map: HashMap;
     data_points: opt vec DataPoint;
+    queries: nat64;
+    errors: nat32;
+    max_queries: nat32;
+    max_errors: nat64;
+    invalid_responses: nat32;
+    seed: nat32;
     llm_data_points: opt vec LLMDataPoint;
     prompt_template: opt text;
     counter_factual: opt CounterFactualModelEvaluationResult;

--- a/src/FAI3_backend/FAI3_backend.did
+++ b/src/FAI3_backend/FAI3_backend.did
@@ -299,10 +299,10 @@ service : () -> {
       vec PrivilegedIndex, vec PrivilegedIndex, vec PrivilegedIndex, vec PrivilegedIndex, float32, float32, float32
     );
 
-    "calculate_llm_metrics": (nat, text, nat64, nat32) -> (variant { Ok: LLMMetricsAPIResult; Err: text });
+    "calculate_llm_metrics": (nat, text, nat64, nat32, nat32) -> (variant { Ok: LLMMetricsAPIResult; Err: text });
     "average_llm_metrics": (nat, vec text) -> (variant {Ok: AverageLLMFairnessMetrics; Err: GenericError });
     "llm_fairness_datasets": () -> (vec text) query;
-    "calculate_all_llm_metrics": (nat, nat64, nat32) -> (variant { Ok: LLMMetricsAPIResult; Err: text }); 
+    "calculate_all_llm_metrics": (nat, nat64, nat32, nat32) -> (variant { Ok: LLMMetricsAPIResult; Err: text }); 
 
     // Example data
     //"add_example_data_points": (nat) -> ();
@@ -318,7 +318,7 @@ service : () -> {
     "get_llm_model_data": (Model) -> (LLMModelData) query;
     "get_llm_model_data_id": (nat) -> (LLMModelData) query;
 
-    "context_association_test": (nat, nat64, nat32, bool) -> (variant { Ok: ContextAssociationTestAPIResult; Err: GenericError });
+    "context_association_test": (nat, nat64, nat32, bool, nat32) -> (variant { Ok: ContextAssociationTestAPIResult; Err: GenericError });
 
     "set_config": (text, text) -> ();
     "get_config": (text) -> (variant { Ok: text; Err: GenericError }) query;

--- a/src/FAI3_backend/FAI3_backend.did
+++ b/src/FAI3_backend/FAI3_backend.did
@@ -148,6 +148,7 @@ type LLMModelData = record {
      evaluations: vec ModelEvaluationResult;
      language_evaluations: vec LanguageEvaluationResult;
      average_fairness_metrics: opt AverageLLMFairnessMetrics;
+     inference_provider: opt text;
 };
 
 type ModelType = variant {
@@ -287,7 +288,7 @@ service : () -> {
 
     // Model management
     "add_classifier_model": (text, ModelDetails) -> (nat);
-    "add_llm_model": (text, text, ModelDetails) -> (nat);
+    "add_llm_model": (text, text, ModelDetails, opt text) -> (nat);
     "delete_model": (nat) -> ();
     "add_owner": (nat, principal) -> ();
     "get_owners": (nat) -> (vec principal);

--- a/src/FAI3_backend/FAI3_backend.did
+++ b/src/FAI3_backend/FAI3_backend.did
@@ -267,6 +267,17 @@ type LanguageEvaluationResult = record {
     max_queries: nat64;
 };
 
+type LanguageEvaluationCounts = record {
+    total_count : nat64;
+    per_language : vec record { text; nat64 };
+};
+
+type CatElementCounts = record {
+    intrasentence_count : nat64;
+    intersentence_count : nat64;
+    total_count : nat64;
+};
+
 service : () -> {
     // User management
     "whoami": () -> (principal);
@@ -301,7 +312,7 @@ service : () -> {
 
     "calculate_llm_metrics": (nat, text, nat64, nat32, nat32) -> (variant { Ok: LLMMetricsAPIResult; Err: text });
     "average_llm_metrics": (nat, vec text) -> (variant {Ok: AverageLLMFairnessMetrics; Err: GenericError });
-    "llm_fairness_datasets": () -> (vec text) query;
+    "llm_fairness_datasets": () -> (vec record {text; nat64}) query;
     "calculate_all_llm_metrics": (nat, nat64, nat32, nat32) -> (variant { Ok: LLMMetricsAPIResult; Err: text }); 
 
     // Example data
@@ -319,9 +330,11 @@ service : () -> {
     "get_llm_model_data_id": (nat) -> (LLMModelData) query;
 
     "context_association_test": (nat, nat64, nat32, bool, nat32) -> (variant { Ok: ContextAssociationTestAPIResult; Err: GenericError });
+    get_cat_element_counts : () -> (CatElementCounts) query;
 
     "set_config": (text, text) -> ();
     "get_config": (text) -> (variant { Ok: text; Err: GenericError }) query;
 
     "llm_evaluate_languages": (model_id : nat, languages : vec text, max_queries : nat64, seed : nat32) -> (variant { Ok : LanguageEvaluationResult; Err : text });
+    get_language_evaluation_counts : () -> (LanguageEvaluationCounts) query;
 }

--- a/src/FAI3_backend/FAI3_backend.did
+++ b/src/FAI3_backend/FAI3_backend.did
@@ -308,7 +308,7 @@ service : () -> {
     //"add_example_data_points": (nat) -> ();
 
     // Model retrieval queries
-    "get_all_models": () -> (vec Model) query;
+    "get_all_models": (nat64, nat64, opt text) -> (vec Model) query;
     "get_model_data_points": (nat) -> (vec DataPoint) query;
     "get_model_metrics": (nat) -> (Metrics) query;
     "get_model": (nat) -> (Model) query;

--- a/src/FAI3_backend/src/config_management.rs
+++ b/src/FAI3_backend/src/config_management.rs
@@ -5,6 +5,7 @@ use crate::errors::GenericError;
 use crate::admin_management::only_admin;
 
 pub const HUGGING_FACE_API_KEY_CONFIG_KEY: &str = "hugging_face_api_key";
+pub const HUGGING_FACE_INFERENCE_PROVIDER_CONFIG_KEY: &str = "hugging_face_inference_provider";
 
 #[ic_cdk::update]
 pub fn set_config(config_key: String, config_value: String) {

--- a/src/FAI3_backend/src/config_management.rs
+++ b/src/FAI3_backend/src/config_management.rs
@@ -5,7 +5,6 @@ use crate::errors::GenericError;
 use crate::admin_management::only_admin;
 
 pub const HUGGING_FACE_API_KEY_CONFIG_KEY: &str = "hugging_face_api_key";
-pub const HUGGING_FACE_INFERENCE_PROVIDER_CONFIG_KEY: &str = "hugging_face_inference_provider";
 
 #[ic_cdk::update]
 pub fn set_config(config_key: String, config_value: String) {

--- a/src/FAI3_backend/src/context_association_test.rs
+++ b/src/FAI3_backend/src/context_association_test.rs
@@ -3,7 +3,7 @@ use regex::Regex;
 use ic_cdk_macros::*;
 use std::fmt;
 use crate::hugging_face::call_hugging_face;
-use crate::types::{ContextAssociationTestResult, ContextAssociationTestMetrics, ContextAssociationTestMetricsBag, ContextAssociationTestDataPoint, ContextAssociationTestType, get_llm_model_data, ModelType, ContextAssociationTestAPIResult};
+use crate::types::{ContextAssociationTestResult, ContextAssociationTestMetrics, ContextAssociationTestMetricsBag, ContextAssociationTestDataPoint, ContextAssociationTestType, get_llm_model_data, ModelType, ContextAssociationTestAPIResult, LLMModelData};
 use crate::{check_cycles_before_action, MODELS, NEXT_LLM_DATA_POINT_ID};
 use crate::admin_management::only_admin;
 use crate::errors::GenericError;
@@ -257,16 +257,16 @@ fn clean_llm_response(text: &String) -> String {
 /// # Parameters
 /// - `prompt: String`: The full prompt to send to Hugging Face.
 /// - `option_indices_definition: Vec<ContextAssociationTestResult>`: vector with option definitions in the order they appear in the prompt.
-/// - `hf_model: String`: string for the HF model
-/// - `seed: u32`: seedt for HF
+/// - `model_data: &LLMModelData`
+/// - `seed: u32`: seed for HF
 ///
 /// # Returns
 /// - `Result<(ContextAssociationTestResult, String), String>`: if Ok(), it returns the result and the full text response (that might be cut because of the stop token options). Otherwise it returns the error message. If the model returns something unexpected but the call didn't fail, it's considered an Ok() response of the ContextAssociationTestResult::Other type. 
 ///
-async fn cat_generic_call(prompt: String, option_indices_definition: Vec<ContextAssociationTestResult>, hf_model: String, seed: u32) -> Result<(ContextAssociationTestResult, String), String> {
+async fn cat_generic_call(prompt: String, option_indices_definition: Vec<ContextAssociationTestResult>, model_data: &LLMModelData, seed: u32) -> Result<(ContextAssociationTestResult, String), String> {
     ic_cdk::println!("Prompt: {}", prompt);
 
-    let response = call_hugging_face(prompt, hf_model, seed, None).await;
+    let response = call_hugging_face(prompt, model_data.hugging_face_url.clone(), seed, None, &model_data.inference_provider).await;
 
     match response {
         Ok(ret) => {
@@ -305,7 +305,7 @@ async fn cat_generic_call(prompt: String, option_indices_definition: Vec<Context
 /// Does a intrasentence context association test against a Hugging Face model.
 ///
 /// # Parameters
-/// - `hf_model: String`: Hugging Face model to test.
+/// - `model_data: &LLMModelData`
 /// - `entry: IntersentenceEntry`: intrasentence context association test data.
 /// - `seed: u32`: seed for Hugging Face API.
 /// - `shuffle_questions: bool`: whether to shuffle the options given the LLM to avoid order bias or not.
@@ -313,11 +313,11 @@ async fn cat_generic_call(prompt: String, option_indices_definition: Vec<Context
 /// # Returns
 /// - `Result<ContextAssociationTestDataPoint, String>`: it returns a datapoint if the call was successful, otherwise it returns the error string.
 ///
-async fn cat_intrasentence_call(hf_model: String, entry: &IntrasentenceEntry, seed: u32, shuffle_questions: bool) -> Result<ContextAssociationTestDataPoint, String> {
+async fn cat_intrasentence_call(model_data: &LLMModelData, entry: &IntrasentenceEntry, seed: u32, shuffle_questions: bool) -> Result<ContextAssociationTestDataPoint, String> {
 
     let (full_prompt, option_indices_definition) = generate_intrasentence_prompt(entry, shuffle_questions, seed);
 
-    let ret = cat_generic_call(full_prompt.clone(), option_indices_definition, hf_model, seed).await;
+    let ret = cat_generic_call(full_prompt.clone(), option_indices_definition, model_data, seed).await;
 
     let mut data_point = ContextAssociationTestDataPoint {
         data_point_id: 0,
@@ -354,7 +354,7 @@ async fn cat_intrasentence_call(hf_model: String, entry: &IntrasentenceEntry, se
 /// Does a intersentence context association test against a Hugging Face model.
 ///
 /// # Parameters
-/// - `hf_model: String`: Hugging Face model to test.
+/// - `model_data: &LLMModelData`
 /// - `entry: IntersentenceEntry`: intersentence context association test data.
 /// - `seed: u32`: seed for Hugging Face API.
 /// - `shuffle_questions: bool`: whether to shuffle the options given the LLM to avoid order bias or not.
@@ -362,11 +362,11 @@ async fn cat_intrasentence_call(hf_model: String, entry: &IntrasentenceEntry, se
 /// # Returns
 /// - `Result<ContextAssociationTestDataPoint, String>`: it returns a datapoint if the call was successful, otherwise it returns the error string.
 ///
-async fn cat_intersentence_call(hf_model: String, entry: &IntersentenceEntry, seed: u32, shuffle_questions:bool) -> Result<ContextAssociationTestDataPoint, String> {
+async fn cat_intersentence_call(model_data: &LLMModelData, entry: &IntersentenceEntry, seed: u32, shuffle_questions:bool) -> Result<ContextAssociationTestDataPoint, String> {
     
     let (full_prompt, option_indices_definition) = generate_intersentence_prompt(entry, shuffle_questions, seed);
     
-    let ret = cat_generic_call(full_prompt.clone(), option_indices_definition, hf_model, seed).await;
+    let ret = cat_generic_call(full_prompt.clone(), option_indices_definition, model_data, seed).await;
 
     let mut data_point = ContextAssociationTestDataPoint {
         data_point_id: 0,
@@ -400,10 +400,21 @@ async fn cat_intersentence_call(hf_model: String, entry: &IntersentenceEntry, se
     }
 }
 
+// Seed cannot be 0 because then the result won't be deterministic 
+fn generate_seed(original_seed: u32, queries: u32) -> u32 {
+    let seed = original_seed * queries + 1;
+
+    if seed == 0 { // overflow edge case
+        return 1;
+    }
+
+    return seed;
+}
+
 /// Execute a series of intersentence Context Association tests against a Hugging Face model.
 ///
 /// # Parameters
-/// - `hf_model: String`: Hugging Face model to test.
+/// - `model_data: &LLMModelData`
 /// - `intra_data: &mut Vec<IntrasentenceEntry>`: vector of intersentence entries.
 /// - `general_metrics: &mut ContextAssociationTestMetrics`: metrics in which to store the results of the test.
 /// - `inter_metrics: &mut ContextAssociationTestMetrics`: metrics in which to store the results of the test.
@@ -420,7 +431,7 @@ async fn cat_intersentence_call(hf_model: String, entry: &IntersentenceEntry, se
 /// - `Result<(u32, u32), String>`: if Ok(), returns a uint with the number of queries and the number of errors. Otherwise, it returns an error description.
 ///
 async fn process_context_association_test_intrasentence(
-    hf_model: String,
+    model_data: &LLMModelData, 
     intra_data: &mut Vec<IntrasentenceEntry>,
     general_metrics: &mut ContextAssociationTestMetrics,
     intra_metrics: &mut ContextAssociationTestMetrics,
@@ -447,7 +458,7 @@ async fn process_context_association_test_intrasentence(
         ic_cdk::println!("Target Bias Type: {}", entry.bias_type);
         let bias_type = entry.bias_type.clone();
 
-        let resp = cat_intrasentence_call(hf_model.clone(), entry, seed * (queries as u32), shuffle_questions).await;
+        let resp = cat_intrasentence_call(&model_data, &entry, generate_seed(seed, queries as u32), shuffle_questions).await;
 
         match resp {
             Ok(data_point) => {
@@ -495,7 +506,7 @@ async fn process_context_association_test_intrasentence(
 /// Execute a series of intersentence Context Association tests against a Hugging Face model.
 ///
 /// # Parameters
-/// - `hf_model: String`: Hugging Face model to test.
+/// - `model_data: &LLMModelData`
 /// - `inter_data: &mut Vec<IntersentenceEntry>`: vector of intersentence entries.
 /// - `general_metrics: &mut ContextAssociationTestMetrics`: metrics in which to store the results of the test.
 /// - `inter_metrics: &mut ContextAssociationTestMetrics`: metrics in which to store the results of the test.
@@ -512,7 +523,7 @@ async fn process_context_association_test_intrasentence(
 /// - `Result<(u32, u32), String>`: if Ok(), returns a uint with the number of queries and the number of errors. Otherwise, it returns an error description.
 ///
 async fn process_context_association_test_intersentence(
-    hf_model: String,
+    model_data: &LLMModelData,
     inter_data: &mut Vec<IntersentenceEntry>,
     general_metrics: &mut ContextAssociationTestMetrics,
     inter_metrics: &mut ContextAssociationTestMetrics,
@@ -538,7 +549,7 @@ async fn process_context_association_test_intersentence(
 
         ic_cdk::println!("Target Bias Type: {}", entry.bias_type);
         let bias_type = entry.bias_type.clone();
-        let resp = cat_intersentence_call(hf_model.clone(), entry, seed * (queries as u32), shuffle_questions).await;
+        let resp = cat_intersentence_call(&model_data, entry, generate_seed(seed, queries as u32), shuffle_questions).await;
 
         match resp {
             Ok(data_point) => {
@@ -621,7 +632,7 @@ pub async fn get_cat_data_points(llm_model_id: u128, cat_metrics_idx: usize, lim
 /// Execute a series of Context Association tests against a Hugging Face model.
 ///
 /// # Parameters
-/// - `hf_model: String`: Hugging Face model to test.
+/// - `model_data: &LLMModelData`
 /// - `max_queries: usize`: Max queries to execute. If it's 0, it will execute all the queries.
 /// - `seed: u32`: Seed for Hugging face API.
 /// - `shuffle_questions: bool`: whether to shuffle the questions and the options given the LLM.
@@ -635,24 +646,15 @@ pub async fn context_association_test(llm_model_id: u128, max_queries: usize, se
     check_cycles_before_action();
     let caller = ic_cdk::api::caller();
 
-    let mut hf_model: String = String::new();
-    let mut model_found = false;
-
     // Needs to be done this way because Rust doesn't support async closures yet
-    MODELS.with(|models| {
-        let models = models.borrow_mut();
-        let model_result = models.get(&llm_model_id);
-        if let Some(model) = model_result {
-            is_owner(&model, caller);
-            let model_data = get_llm_model_data(&model);
-            hf_model = model_data.hugging_face_url;
-            model_found = true;
-        }
-    });
-
-    if !model_found {
-        return Err(GenericError::new(GenericError::NOT_FOUND, "Model not found"));
-    }
+    let model_data = MODELS.with(|models| {
+       let models = models.borrow_mut();
+        models.get(&llm_model_id)
+            .map(|model| {
+                is_owner(&model, caller);
+                get_llm_model_data(&model)
+            })
+    }).ok_or_else(|| GenericError::new(GenericError::NOT_FOUND, "Model not found"))?;
     
     let cat_json = include_str!("context_association_test_processed.json");
     let parsed_data: Result<CatJson, _> = serde_json::from_str(cat_json).map_err(|e| e.to_string());
@@ -678,7 +680,7 @@ pub async fn context_association_test(llm_model_id: u128, max_queries: usize, se
         let mut data_points = Vec::<ContextAssociationTestDataPoint>::new();
 
         let mut intra_data = inner.data.intrasentence;
-        let res = process_context_association_test_intrasentence(hf_model.clone(), &mut intra_data, &mut general_metrics, &mut intra_metrics, &mut gender_metrics, &mut race_metrics, &mut profession_metrics, &mut religion_metrics, &mut data_points, max_queries / 2, seed, shuffle_questions, max_errors).await;
+        let res = process_context_association_test_intrasentence(&model_data, &mut intra_data, &mut general_metrics, &mut intra_metrics, &mut gender_metrics, &mut race_metrics, &mut profession_metrics, &mut religion_metrics, &mut data_points, max_queries / 2, seed, shuffle_questions, max_errors).await;
         match res {
             Ok((queries, err_count)) => {
                 error_count += err_count;
@@ -688,7 +690,7 @@ pub async fn context_association_test(llm_model_id: u128, max_queries: usize, se
         }
 
         let mut inter_data = inner.data.intersentence;
-        let res = process_context_association_test_intersentence(hf_model, &mut inter_data, &mut general_metrics, &mut inter_metrics, &mut gender_metrics, &mut race_metrics, &mut profession_metrics, &mut religion_metrics, &mut data_points, max_queries / 2, seed, shuffle_questions, max_errors - error_count).await;
+        let res = process_context_association_test_intersentence(&model_data, &mut inter_data, &mut general_metrics, &mut inter_metrics, &mut gender_metrics, &mut race_metrics, &mut profession_metrics, &mut religion_metrics, &mut data_points, max_queries / 2, seed, shuffle_questions, max_errors - error_count).await;
         match res {
             Ok((queries, err_count)) => {
                 error_count += err_count;

--- a/src/FAI3_backend/src/hugging_face.rs
+++ b/src/FAI3_backend/src/hugging_face.rs
@@ -1,113 +1,98 @@
 use crate::CONFIGURATION;
-use crate::config_management::{
-    HUGGING_FACE_API_KEY_CONFIG_KEY,
-    HUGGING_FACE_INFERENCE_PROVIDER_CONFIG_KEY,
-};
+use crate::config_management::HUGGING_FACE_API_KEY_CONFIG_KEY;
 use serde::{Deserialize, Serialize};
+
+use super::inference_providers::{
+    InferenceProvider,
+    novita::NovitaProvider,
+    together::TogetherAIProvider,
+    nebius::NebiusProvider,
+    none::NoneProvider,
+    lib::HuggingFaceRequestParameters,
+};
 
 use ic_cdk::api::management_canister::http_request::{
     http_request, CanisterHttpRequestArgument, HttpHeader, HttpMethod, HttpResponse,
 };
 
+use ic_cdk::api::management_canister::http_request::{TransformContext, TransformFunc, TransformArgs};
+
 use num_traits::cast::ToPrimitive;
-use crate::types::HuggingFaceResponseItem;
 
-const HUGGING_FACE_ENDPOINT: &str = "https://api-inference.huggingface.co/models";
-const HUGGING_FACE_INFERENCE_PROVIDER_URL: &str = "https://router.huggingface.co";
-
-#[derive(Serialize, Deserialize, Clone)]
-pub struct HuggingFaceRequestParameters {
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub stop: Option<Vec<char>>,
-    pub max_new_tokens: Option<u32>,
-    pub temperature: Option<f32>,
-    pub return_full_text: Option<bool>,
-    pub decoder_input_details: Option<bool>,
-    pub details: Option<bool>,
-    pub seed: Option<u32>,
-    pub do_sample: Option<bool>,
-}
-
+// This struct is legacy code and is not really used in the code.
 #[derive(Serialize, Deserialize)]
-pub struct HuggingFaceRequest {
-    inputs: String,
-    parameters: Option<HuggingFaceRequestParameters>,
+struct Context {
+    bucket_start_time_index: usize,
+    closing_price_index: usize,
 }
 
-#[derive(Serialize, Deserialize, Debug)]
-pub struct HuggingFaceResponse {
-    generated_text: Option<String>,
-}
+// Necessary function to remove the non-determinism "id" and "created" values
+// It replaces them with ""
+#[ic_cdk::query]
+fn transform_hf_response(raw: TransformArgs) -> HttpResponse {
+    // This might not be necessary, but we are overriding the headers
+    // Just in case they return anything variable
+    let headers = vec![
+        HttpHeader {
+            name: "Content-Security-Policy".to_string(),
+            value: "default-src 'self'".to_string(),
+        },
+        HttpHeader {
+            name: "Referrer-Policy".to_string(),
+            value: "strict-origin".to_string(),
+        },
+        HttpHeader {
+            name: "Permissions-Policy".to_string(),
+            value: "geolocation=(self)".to_string(),
+        },
+        HttpHeader {
+            name: "Strict-Transport-Security".to_string(),
+            value: "max-age=63072000".to_string(),
+        },
+        HttpHeader {
+            name: "X-Frame-Options".to_string(),
+            value: "DENY".to_string(),
+        },
+        HttpHeader {
+            name: "X-Content-Type-Options".to_string(),
+            value: "nosniff".to_string(),
+        },
+    ];
 
-#[derive(Serialize, Deserialize)]
-struct NovitaResponse {
-    choices: Vec<NovitaChoice>,
-    created: i64,
-    id: String,
-    model: String,
-    object: String,
-    system_fingerprint: String,
-    usage: NovitaUsage,
-}
+    let body: Vec::<u8>;
+    let status = raw.response.status.clone();
+    if status != 200_u16 {
+        ic_cdk::api::print(format!("Transform function: received an error from Hugging Face: err = {:?}", raw));  
+        return raw.response;
+    }
 
-#[derive(Serialize, Deserialize)]
-struct NovitaChoice {
-    content_filter_results: NovitaContentFilterResults,
-    finish_reason: String,
-    index: i32,
-    message: NovitaMessage,
-}
+    let res = raw.response;
+    if let Ok(mut json) = serde_json::from_slice::<serde_json::Value>(&res.body) {
+        // id and created field are variable, so this converts them to ""
+        if let Some(obj) = json.as_object_mut() {
+            // Novita, Nebius, TogetherAI use this struture
+            // Cleaning "id" and "created" fields
+            if let Some(id) = obj.get_mut("id") {
+                *id = serde_json::Value::String("".to_string());
+            }
+            if let Some(created) = obj.get_mut("created") {
+                ic_cdk::println!("Changing created");
+                *created = serde_json::Value::Number(serde_json::Number::from(0));
+            }
+        }
+        body = serde_json::to_vec(&json).unwrap_or(res.body);
+    } else {
+        body = res.body;
+    }
 
-#[derive(Serialize, Deserialize)]
-struct NovitaContentFilterResults {
-    hate: NovitaFilterResult,
-    jailbreak: NovitaJailbreakResult,
-    profanity: NovitaFilterResult,
-    self_harm: NovitaFilterResult,
-    sexual: NovitaFilterResult,
-    violence: NovitaFilterResult,
-}
+    let res = HttpResponse {
+        status,
+        body,
+        headers,
+        ..Default::default()
+    };
 
-#[derive(Serialize, Deserialize)]
-struct NovitaFilterResult {
-    filtered: bool,
-    #[serde(default)]
-    detected: bool,
-}
-
-#[derive(Serialize, Deserialize)]
-struct NovitaJailbreakResult {
-    detected: bool,
-    filtered: bool,
-}
-
-#[derive(Serialize, Deserialize)]
-struct NovitaMessage {
-    content: String,
-    role: String,
-}
-
-#[derive(Serialize, Deserialize)]
-struct NovitaUsage {
-    completion_tokens: i32,
-    completion_tokens_details: Option<serde_json::Value>,
-    prompt_tokens: i32,
-    prompt_tokens_details: Option<serde_json::Value>,
-    total_tokens: i32,
-}
-
-// OpenAI compatible API request, for inference providers
-#[derive(Serialize, Deserialize, Clone)]
-pub struct OpenAIRequest {
-    model: String,
-    messages: Vec<OpenAIMessage>,
-    max_tokens: Option<u32>,
-}
-
-#[derive(Serialize, Deserialize, Clone)]
-pub struct OpenAIMessage {
-    role: String,
-    content: String,
+    res
 }
 
 /// Calls Hugging Face, returning the HF response.
@@ -120,7 +105,14 @@ pub struct OpenAIMessage {
 /// # Returns
 /// - `Result<String, String>`: if successful, it returns the model answer, without the prompt text. Otherwise, it returns an error description.
 ///
-pub async fn call_hugging_face(input_text: String, llm_model: String, seed: u32, hf_parameters: Option<HuggingFaceRequestParameters>) -> Result<String, String> {
+pub async fn call_hugging_face(input_text: String, llm_model: String, seed: u32, hf_parameters: Option<HuggingFaceRequestParameters>, inference_provider: &Option<String>) -> Result<String, String> {
+
+    let hugging_face_bearer_token = CONFIGURATION.with(|config| {
+        let config_tree = config.borrow();
+
+        let not_found_error_message = format!("{} config key should be set.", HUGGING_FACE_API_KEY_CONFIG_KEY.to_string());
+        return config_tree.get(&HUGGING_FACE_API_KEY_CONFIG_KEY.to_string()).expect(not_found_error_message.as_str());
+    });
 
     let default_parameters = HuggingFaceRequestParameters {
         max_new_tokens: Some(100),
@@ -138,24 +130,29 @@ pub async fn call_hugging_face(input_text: String, llm_model: String, seed: u32,
     if let Some(p) = hf_parameters {
         parameters = p;
     }
-    
-    // 1) Prepare JSON payload
-    let payload = HuggingFaceRequest {
-        inputs: input_text.clone(),
-        parameters: Some(parameters), 
+
+    let provider: Box<dyn InferenceProvider> = if let Some(_provider) = inference_provider.clone() {
+        ic_cdk::println!("configured provider: {}", _provider);
+        match _provider.as_str() {
+            "novita" => Box::new(NovitaProvider{}),
+            "togetherai" => Box::new(TogetherAIProvider{}),
+            "nebius" => Box::new(NebiusProvider{}),
+            p => {
+                ic_cdk::println!("No known provider {}, using NoneProvider", p);
+                Box::new(NoneProvider{})
+            }
+        }
+    } else {
+        Box::new(NoneProvider{})
     };
 
-    let mut json_payload =
-        serde_json::to_vec(&payload).map_err(|e| format!("Failed to serialize payload: {}", e))?;
+    ic_cdk::println!("Using {} provider", provider.name());
+
+    // 1) Generate payload
+    let json_payload = provider.generate_payload(llm_model.clone(), input_text, parameters)?;
 
     // ic_cdk::println!("{}", String::from_utf8(json_payload.clone()).unwrap());
-
-    let hugging_face_bearer_token = CONFIGURATION.with(|config| {
-        let config_tree = config.borrow();
-
-        let not_found_error_message = format!("{} config key should be set.", HUGGING_FACE_API_KEY_CONFIG_KEY.to_string());
-        return config_tree.get(&HUGGING_FACE_API_KEY_CONFIG_KEY.to_string()).expect(not_found_error_message.as_str());
-    });
+ 
 
     // 2) Prepare headers
     let headers = vec![
@@ -172,40 +169,23 @@ pub async fn call_hugging_face(input_text: String, llm_model: String, seed: u32,
     // 3) Construct the argument
     //    - Wrap json_payload in Some(...)
     //    - Provide max_response_bytes (e.g., 2 MB)
-    let endpoint_url = HUGGING_FACE_ENDPOINT.to_string();
+    let url = provider.endpoint_url(llm_model);
 
-    let inference_provider = CONFIGURATION.with(|config| {
-        let config_tree = config.borrow();
-
-        return config_tree.get(&HUGGING_FACE_INFERENCE_PROVIDER_CONFIG_KEY.to_string()); 
+    // From: https://github.com/dfinity/examples/blob/master/rust/send_http_post/src/send_http_post_backend/src/lib.rsL80
+    let context = Context {
+        bucket_start_time_index: 0,
+        closing_price_index: 4,
+    };
+    let transform = Some(TransformContext {
+        context: serde_json::to_vec(&context).unwrap(),
+        function: TransformFunc(candid::Func {
+            principal: ic_cdk::api::id(),
+            method: "transform_hf_response".to_string(),
+        }),         
     });
 
-    let mut url = format!("{}/{}", endpoint_url, llm_model);
-
-    if let Some(_provider) = inference_provider.clone() {
-        match _provider.as_str() {
-            "novita" => {
-                url = format!("{}/{}", &HUGGING_FACE_INFERENCE_PROVIDER_URL.to_string(), "novita/v3/openai/chat/completions");
-
-                let payload = OpenAIRequest {
-                    model: llm_model.to_lowercase(),
-                    messages: vec![
-                        OpenAIMessage {
-                            role: "user".to_string(),
-                            content: input_text
-                        }
-                    ],
-                    max_tokens: Some(5000),
-                };
-
-                json_payload =
-        serde_json::to_vec(&payload).map_err(|e| format!("Failed to serialize payload: {}", e))?;
-            },
-            _ => (),
-        }
-    }
-    
     ic_cdk::println!("Endpoint url: {}", url);
+    ic_cdk::println!("json payload: {}", String::from_utf8_lossy(&json_payload));
     
     let request_arg = CanisterHttpRequestArgument {
         url,
@@ -213,7 +193,7 @@ pub async fn call_hugging_face(input_text: String, llm_model: String, seed: u32,
         headers,
         body: Some(json_payload),
         max_response_bytes: Some(2_000_000),
-        transform: None,
+        transform,
     };
 
     // 4) Make the outcall. The second param is cycles to spend (0 if none).
@@ -232,43 +212,13 @@ pub async fn call_hugging_face(input_text: String, llm_model: String, seed: u32,
         ));
     }
 
+    ic_cdk::println!("Json response: {}", String::from_utf8_lossy(&response.body));
+
     // 1) Parse raw bytes into a `serde_json::Value`
     let json_val: serde_json::Value =
         serde_json::from_slice(&response.body).map_err(|e| e.to_string())?;
 
     ic_cdk::println!("HF response: {}", &json_val);
 
-    let text: String;
-
-    match inference_provider {
-        Some(ref prov) if prov == "novita" => {
-            // assume it's Novita
-            
-            // 2) Now parse that `json_val` into a vector of your items
-            let hf_response: NovitaResponse =
-                serde_json::from_value(json_val).map_err(|e| e.to_string())?;
-
-            // 3) Extract the text from the first item, or default
-            text = hf_response
-                .choices.get(0)
-                .expect("it should have at least one choice")
-                .message
-                .content.clone();
-        },
-        _ => {
-            // 2) Now parse that `json_val` into a vector of your items
-            let hf_response: Vec<HuggingFaceResponseItem> =
-                serde_json::from_value(json_val).map_err(|e| e.to_string())?;
-
-            // 3) Extract the text from the first item, or default
-            text = hf_response
-                .get(0)
-                .and_then(|item| item.generated_text.clone())
-                .unwrap_or_else(|| "No generated_text".to_string());
-        }
-    };
-
-
-    // 4) Return a `String` in `Ok(...)`
-    Ok(text)
+    return provider.get_response_text(&response.body);
 }

--- a/src/FAI3_backend/src/hugging_face.rs
+++ b/src/FAI3_backend/src/hugging_face.rs
@@ -195,7 +195,7 @@ pub async fn call_hugging_face(input_text: String, llm_model: String, seed: u32,
                             content: input_text
                         }
                     ],
-                    max_tokens: Some(1000),
+                    max_tokens: Some(5000),
                 };
 
                 json_payload =

--- a/src/FAI3_backend/src/inference_providers/lib.rs
+++ b/src/FAI3_backend/src/inference_providers/lib.rs
@@ -1,0 +1,41 @@
+use serde::{Deserialize, Serialize};
+
+pub const HUGGING_FACE_ENDPOINT: &str = "https://api-inference.huggingface.co/models";
+pub const HUGGING_FACE_INFERENCE_PROVIDER_URL: &str = "https://router.huggingface.co";
+
+// OpenAI compatible API request, for inference providers
+#[derive(Serialize, Deserialize, Clone)]
+pub struct OpenAIRequest {
+    pub model: String,
+    pub messages: Vec<OpenAIMessage>,
+    pub max_tokens: Option<u32>,
+    pub seed: Option<u32>,
+    pub do_sample: Option<bool>,
+    pub stream: bool,
+    pub temperature: Option<f32>,
+}
+
+#[derive(Serialize, Deserialize, Clone)]
+pub struct OpenAIMessage {
+    pub role: String,
+    pub content: String,
+}
+
+#[derive(Serialize, Deserialize, Clone)]
+pub struct HuggingFaceRequestParameters {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stop: Option<Vec<char>>,
+    pub max_new_tokens: Option<u32>,
+    pub temperature: Option<f32>,
+    pub return_full_text: Option<bool>,
+    pub decoder_input_details: Option<bool>,
+    pub details: Option<bool>,
+    pub seed: Option<u32>,
+    pub do_sample: Option<bool>,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct HuggingFaceRequest {
+    pub inputs: String,
+    pub parameters: Option<HuggingFaceRequestParameters>,
+}

--- a/src/FAI3_backend/src/inference_providers/mod.rs
+++ b/src/FAI3_backend/src/inference_providers/mod.rs
@@ -1,0 +1,19 @@
+pub mod traits;
+pub mod novita;
+pub mod together;
+pub mod nebius;
+pub mod none;
+pub mod lib;
+
+// Re-export the trait and providers
+pub use traits::InferenceProvider;
+pub use novita::NovitaProvider;
+pub use together::TogetherAIProvider;
+pub use nebius::NebiusProvider;
+pub use none::NoneProvider;
+pub use lib::{
+    HuggingFaceRequestParameters,
+    HuggingFaceRequest,
+    HUGGING_FACE_ENDPOINT,
+    HUGGING_FACE_INFERENCE_PROVIDER_URL,
+};

--- a/src/FAI3_backend/src/inference_providers/nebius.rs
+++ b/src/FAI3_backend/src/inference_providers/nebius.rs
@@ -1,0 +1,57 @@
+pub struct NebiusProvider {}
+
+use super::traits::InferenceProvider;
+use super::lib::{
+    HuggingFaceRequestParameters,
+    HUGGING_FACE_INFERENCE_PROVIDER_URL,
+    OpenAIRequest,
+    OpenAIMessage,
+};
+
+use super::together::TogetherAIResponse;
+
+impl InferenceProvider for NebiusProvider {
+    fn name(&self) -> &str {
+        return "nebius";
+    }
+    
+    fn generate_payload(&self, llm_model: String, input_text: String, parameters: HuggingFaceRequestParameters) -> Result<Vec<u8>, String> {
+        let payload = OpenAIRequest {
+            model: llm_model,
+            messages: vec![
+                OpenAIMessage {
+                    role: "user".to_string(),
+                    content: input_text,
+                }
+            ],
+            stream: false,
+            max_tokens: Some(5000),
+            seed: parameters.seed,
+            do_sample: Some(false),
+            temperature: Some(0.0),
+        };
+
+        return serde_json::to_vec(&payload).map_err(|e| format!("Failed to serialize payload: {}", e));
+    }
+
+    fn get_response_text(&self, response_body: &Vec<u8>) -> Result<String, String> {
+        // Since Nebius uses same format as TogetherAI, we can reuse the same response structure
+        let json_val: serde_json::Value =
+            serde_json::from_slice(&response_body).map_err(|e| e.to_string())?;
+        let nebius_response: TogetherAIResponse = // Reusing TogetherAI response structure
+            serde_json::from_value(json_val).map_err(|e| e.to_string())?;
+        let choice = nebius_response
+            .choices.get(0);
+        if let None = choice {
+            return Err("choices field is empty".to_string());
+        }
+        Ok(choice
+           .unwrap()
+           .message
+           .content.clone())
+    }
+
+    fn endpoint_url(&self, _llm_model: String) -> String {
+        return format!("{}/{}", &HUGGING_FACE_INFERENCE_PROVIDER_URL.to_string(), "nebius/v1/chat/completions");
+    }
+}

--- a/src/FAI3_backend/src/inference_providers/none.rs
+++ b/src/FAI3_backend/src/inference_providers/none.rs
@@ -1,0 +1,60 @@
+use serde::{Deserialize, Serialize};
+
+use crate::types::HuggingFaceResponseItem;
+
+use super::traits::InferenceProvider;
+use super::lib::{
+    HuggingFaceRequestParameters,
+    HuggingFaceRequest,
+    HUGGING_FACE_ENDPOINT,
+};
+
+pub struct NoneProvider {}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct HuggingFaceResponse {
+    generated_text: Option<String>,
+}
+
+impl InferenceProvider for NoneProvider {
+    fn name(&self) -> &str {
+        return "none (Hugging Face API)";
+    }
+    
+    fn generate_payload(&self, _llm_model: String, input_text: String, parameters: HuggingFaceRequestParameters) -> Result<Vec<u8>, String> {
+        let payload = HuggingFaceRequest {
+            inputs: input_text.clone(),
+            parameters: Some(parameters), 
+        };
+
+        let json_payload =
+            serde_json::to_vec(&payload).map_err(|e| format!("Failed to serialize payload: {}", e))?;
+
+        return Ok(json_payload);
+    }
+
+    fn get_response_text(&self, response_body: &Vec<u8>) -> Result<String, String> {
+        // 1) Parse raw bytes into a `serde_json::Value`
+        let json_val: serde_json::Value =
+            serde_json::from_slice(&response_body).map_err(|e| e.to_string())?;
+        
+        // 2) Now parse that `json_val` into a vector of your items
+        let hf_response: Vec<HuggingFaceResponseItem> =
+            serde_json::from_value(json_val).map_err(|e| e.to_string())?;
+
+        // 3) Extract the text from the first item, or default
+        let items = hf_response.get(0);
+
+        if let None = items {
+            return Err("No generated text".to_string());
+        }
+
+        return Ok(items
+                  .and_then(|item| item.generated_text.clone())
+                  .unwrap_or_else(|| "No generated_text".to_string()));
+    }
+
+    fn endpoint_url(&self, llm_model: String) -> String {
+        return format!("{}/{}", HUGGING_FACE_ENDPOINT, llm_model);
+    }
+}

--- a/src/FAI3_backend/src/inference_providers/novita.rs
+++ b/src/FAI3_backend/src/inference_providers/novita.rs
@@ -1,0 +1,121 @@
+pub struct NovitaProvider {}
+
+use serde::{Deserialize, Serialize};
+
+use super::traits::InferenceProvider;
+use super::lib::{
+    HuggingFaceRequestParameters,
+    HUGGING_FACE_INFERENCE_PROVIDER_URL,
+    OpenAIRequest,
+    OpenAIMessage,
+};
+
+// Novita JSON response
+#[derive(Serialize, Deserialize)]
+struct NovitaResponse {
+    choices: Vec<NovitaChoice>,
+    created: i64,
+    id: String,
+    model: String,
+    object: String,
+    system_fingerprint: String,
+    usage: NovitaUsage,
+}
+
+#[derive(Serialize, Deserialize)]
+struct NovitaChoice {
+    content_filter_results: NovitaContentFilterResults,
+    finish_reason: String,
+    index: i32,
+    message: NovitaMessage,
+}
+
+#[derive(Serialize, Deserialize)]
+struct NovitaContentFilterResults {
+    hate: NovitaFilterResult,
+    jailbreak: NovitaJailbreakResult,
+    profanity: NovitaFilterResult,
+    self_harm: NovitaFilterResult,
+    sexual: NovitaFilterResult,
+    violence: NovitaFilterResult,
+}
+
+#[derive(Serialize, Deserialize)]
+struct NovitaFilterResult {
+    filtered: bool,
+    #[serde(default)]
+    detected: bool,
+}
+
+#[derive(Serialize, Deserialize)]
+struct NovitaJailbreakResult {
+    detected: bool,
+    filtered: bool,
+}
+
+#[derive(Serialize, Deserialize)]
+struct NovitaMessage {
+    content: String,
+    role: String,
+}
+
+#[derive(Serialize, Deserialize)]
+struct NovitaUsage {
+    completion_tokens: i32,
+    completion_tokens_details: Option<serde_json::Value>,
+    prompt_tokens: i32,
+    prompt_tokens_details: Option<serde_json::Value>,
+    total_tokens: i32,
+}
+
+impl InferenceProvider for NovitaProvider {
+    fn name(&self) -> &str {
+        return "novita";
+    }
+    
+    fn generate_payload(&self, llm_model: String, input_text: String, parameters: HuggingFaceRequestParameters) -> Result<Vec<u8>, String> {
+        let payload = OpenAIRequest {
+            model: llm_model.to_lowercase(),
+            messages: vec![
+                OpenAIMessage {
+                    role: "user".to_string(),
+                    content: input_text,
+                }
+            ],
+            stream: false,
+            max_tokens: Some(5000),
+            seed: parameters.seed,
+            do_sample: Some(false),
+            temperature: Some(0.0),
+        };
+
+        return serde_json::to_vec(&payload).map_err(|e| format!("Failed to serialize payload: {}", e));
+    }
+
+    fn get_response_text(&self, response_body: &Vec<u8>) -> Result<String, String> {
+        // 1) Parse raw bytes into a `serde_json::Value`
+        let json_val: serde_json::Value =
+            serde_json::from_slice(&response_body).map_err(|e| e.to_string())?;
+        
+        // 2) Now parse that `json_val` into a vector of your items
+        let hf_response: NovitaResponse =
+            serde_json::from_value(json_val).map_err(|e| e.to_string())?;
+
+        // 3) Extract the text from the first item, or default
+        let choice = hf_response
+            .choices.get(0);
+
+        if let None = choice {
+            return Err("choices fields is empty".to_string());
+        }
+
+        Ok(choice
+           .unwrap()
+           .message
+           .content.clone())
+    }
+
+    fn endpoint_url(&self, _llm_model: String) -> String {
+        return format!("{}/{}", &HUGGING_FACE_INFERENCE_PROVIDER_URL.to_string(), "novita/v3/openai/chat/completions");
+    }
+}

--- a/src/FAI3_backend/src/inference_providers/together.rs
+++ b/src/FAI3_backend/src/inference_providers/together.rs
@@ -1,0 +1,97 @@
+use serde::{Deserialize, Serialize};
+
+pub struct TogetherAIProvider {}
+
+use super::traits::InferenceProvider;
+use super::lib::{
+    HuggingFaceRequestParameters,
+    HUGGING_FACE_INFERENCE_PROVIDER_URL,
+    OpenAIRequest,
+    OpenAIMessage,
+};
+
+// TogetherAI JSON response
+#[derive(Serialize, Deserialize)]
+pub struct TogetherAIResponse {
+    pub id: String,
+    pub object: String,
+    pub created: i64,
+    pub model: String,
+    pub prompt: Option<Vec<String>>,
+    pub choices: Vec<TogetherAIChoice>,
+    pub usage: TogetherAIUsage,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct TogetherAIChoice {
+    pub finish_reason: String,
+    pub seed: Option<u32>,
+    pub logprobs: Option<serde_json::Value>,
+    pub index: i32,
+    pub message: TogetherAIMessage,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct TogetherAIMessage {
+    pub role: String,
+    pub content: String,
+    pub tool_calls: Vec<serde_json::Value>,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct TogetherAIUsage {
+    pub prompt_tokens: i32,
+    pub completion_tokens: i32,
+    pub total_tokens: i32,
+}
+
+impl InferenceProvider for TogetherAIProvider {
+    fn name(&self) -> &str {
+        return "togetherai";
+    }
+    
+    fn generate_payload(&self, llm_model: String, input_text: String, parameters: HuggingFaceRequestParameters) -> Result<Vec<u8>, String> {
+        let payload = OpenAIRequest {
+            model: llm_model.to_lowercase(),
+            messages: vec![
+                OpenAIMessage {
+                    role: "user".to_string(),
+                    content: input_text,
+                }
+            ],
+            stream: false,
+            max_tokens: Some(5000),
+            seed: parameters.seed,
+            do_sample: Some(false),
+            temperature: Some(0.0),
+        };
+
+        return serde_json::to_vec(&payload).map_err(|e| format!("Failed to serialize payload: {}", e));
+    }
+
+    fn get_response_text(&self, response_body: &Vec<u8>) -> Result<String, String> {
+        // Parse raw bytes into TogetherAI response format
+        let json_val: serde_json::Value =
+            serde_json::from_slice(&response_body).map_err(|e| e.to_string())?;
+        
+        let together_response: TogetherAIResponse =
+            serde_json::from_value(json_val).map_err(|e| e.to_string())?;
+
+        // Extract the text from the first choice
+        let choice = together_response
+            .choices.get(0);
+
+        if let None = choice {
+            return Err("choices field is empty".to_string());
+        }
+
+        Ok(choice
+           .unwrap()
+           .message
+           .content.clone())
+    }
+
+    fn endpoint_url(&self, _llm_model: String) -> String {
+        return format!("{}/{}", &HUGGING_FACE_INFERENCE_PROVIDER_URL.to_string(), "together/v1/chat/completions");
+    }
+}

--- a/src/FAI3_backend/src/inference_providers/traits.rs
+++ b/src/FAI3_backend/src/inference_providers/traits.rs
@@ -1,0 +1,8 @@
+use super::lib::HuggingFaceRequestParameters;
+
+pub trait InferenceProvider {
+    fn name(&self) -> &str;
+    fn generate_payload(&self, llm_model: String, input_text: String, parameters: HuggingFaceRequestParameters) -> Result<Vec<u8>, String>;
+    fn get_response_text(&self, response_body: &Vec<u8>) -> Result<String, String>;
+    fn endpoint_url(&self, llm_model: String) -> String;
+}

--- a/src/FAI3_backend/src/lib.rs
+++ b/src/FAI3_backend/src/lib.rs
@@ -11,6 +11,7 @@ pub mod llm_language_evaluations;
 mod utils;
 pub mod errors;
 mod config_management;
+pub mod inference_providers;
 
 use errors::GenericError;
 use candid::Principal;

--- a/src/FAI3_backend/src/llm_fairness.rs
+++ b/src/FAI3_backend/src/llm_fairness.rs
@@ -1,5 +1,4 @@
 use ic_cdk_macros::*;
-use regex::Regex;
 use crate::hugging_face::{call_hugging_face, HuggingFaceRequestParameters};
 use crate::types::{DataPoint, LLMDataPoint, ModelType, LLMMetricsAPIResult, Metrics, AverageMetrics, get_llm_model_data, ModelEvaluationResult, PrivilegedMap, KeyValuePair, LLMDataPointCounterFactual, CounterFactualModelEvaluationResult, AverageLLMFairnessMetrics, LLMModelData};
 use crate::{check_cycles_before_action, MODELS, NEXT_LLM_MODEL_EVALUATION_ID, get_model_from_memory};

--- a/src/FAI3_backend/src/llm_language_evaluations.rs
+++ b/src/FAI3_backend/src/llm_language_evaluations.rs
@@ -1,5 +1,6 @@
 use ic_cdk_macros::*;
-use crate::hugging_face::{call_hugging_face, HuggingFaceRequestParameters};
+use crate::hugging_face::call_hugging_face;
+use crate::inference_providers::lib::HuggingFaceRequestParameters;
 use crate::types::{LanguageEvaluationResult, LanguageEvaluationMetrics, ModelType, LLMModelData, LanguageEvaluationDataPoint, get_llm_model_data};
 use crate::{check_cycles_before_action, NEXT_LLM_LANGUAGE_EVALUATION_ID, get_model_from_memory, only_admin};
 use crate::utils::{is_owner, seeded_vector_shuffle};
@@ -122,7 +123,7 @@ async fn run_evaluate_languages(model_data: &LLMModelData, languages: &Vec<Strin
 
             let prompt: String = build_prompt(&question, &options, seed * (queries as u32));
             
-            let res = call_hugging_face(prompt.clone(), model_data.hugging_face_url.clone(), seed, Some(hf_parameters.clone())).await;
+            let res = call_hugging_face(prompt.clone(), model_data.hugging_face_url.clone(), seed, Some(hf_parameters.clone()), &model_data.inference_provider).await;
 
             let trimmed_response = match res {
                 Ok(response) => crate::utils::clean_llm_response(&response),

--- a/src/FAI3_backend/src/model.rs
+++ b/src/FAI3_backend/src/model.rs
@@ -143,11 +143,12 @@ pub fn get_all_models(limit: usize, _offset: usize, model_type: Option<String>) 
         return models
             .values()
             .filter(|model| {
+                ic_cdk::println!("Filtering");
                 match &model_type {
                     Some(ref mt) if mt == "llm" => matches!(model.model_type, ModelType::LLM(_)),
                     Some(ref mt) if mt == "classifier" => matches!(model.model_type, ModelType::Classifier(_)),
                     // if model type is not "llm" or "classifier", it matches everything
-                    _ => true, 
+                    _ => true,
                 }
             })
             .take(limit)

--- a/src/FAI3_backend/src/model.rs
+++ b/src/FAI3_backend/src/model.rs
@@ -5,7 +5,7 @@ use crate::{
 use candid::Principal;
 use std::vec;
 use crate::types::get_classifier_model_data;
-use crate::types::{ModelType, ClassifierModelData, LLMModelData, ModelDetailsHistory, ModelEvaluationResult, LanguageEvaluationResult, get_llm_model_data};
+use crate::types::{ModelType, ClassifierModelData, LLMModelData, ModelDetailsHistory};
 
 #[ic_cdk::update]
 pub fn add_classifier_model(model_name: String, model_details: ModelDetails) -> u128 {
@@ -141,7 +141,6 @@ pub fn get_all_models(limit: usize, _offset: usize, model_type: Option<String>) 
         return models
             .values()
             .filter(|model| {
-                ic_cdk::println!("Filtering");
                 match &model_type {
                     Some(ref mt) if mt == "llm" => matches!(model.model_type, ModelType::LLM(_)),
                     Some(ref mt) if mt == "classifier" => matches!(model.model_type, ModelType::Classifier(_)),
@@ -151,11 +150,7 @@ pub fn get_all_models(limit: usize, _offset: usize, model_type: Option<String>) 
             })
             .take(limit)
             .map(|model| {
-                ic_cdk::println!("Mapping");
-                match &model_type {
-                    Some(ref mt) if mt == "llm" => prune_llm_model(model),
-                    _ => model
-                }
+                model.prune()
             })
             .collect();
     });
@@ -187,36 +182,6 @@ pub fn get_model_metrics(model_id: u128) -> Metrics {
     })
 }
 
-// Takes a model and returns another model with pruned data
-// Useful because data_points contain a lot of data
-// And the protocol doesn't support to return so much data
-pub fn prune_llm_model(mut model: Model) -> Model {
-    // Deleting data that could trigger a response size error
-    // Error code: IC0504
-    let mut model_data = get_llm_model_data(&model);
-
-    model_data.cat_metrics_history = vec![];
-    if let Some(mut cat) = model_data.cat_metrics {
-        cat.data_points = vec![];
-        model_data.cat_metrics = Some(cat);
-    }
-
-    model_data.evaluations = model_data.evaluations.into_iter().map(|mut evaluation: ModelEvaluationResult| {
-        evaluation.data_points = None;
-        evaluation.llm_data_points = None;
-        evaluation
-    }).collect();
-
-    model_data.language_evaluations = model_data.language_evaluations.into_iter().map(|mut levaluation: LanguageEvaluationResult| {
-        levaluation.data_points = Vec::new();
-        levaluation
-    }).collect();
-
-    model.model_type = ModelType::LLM(model_data);
-    
-    return model;
-}
-
 /// Returns a model
 /// For limitations and data size, it won't return LLM data_points
 /// And it won't return LLM metrics history
@@ -230,7 +195,7 @@ pub fn get_model(model_id: u128) -> Model {
             .clone()
     });
 
-    return prune_llm_model(model);
+    model.prune()
 }
 
 #[ic_cdk::update]

--- a/src/FAI3_backend/src/model.rs
+++ b/src/FAI3_backend/src/model.rs
@@ -5,7 +5,7 @@ use crate::{
 use candid::Principal;
 use std::vec;
 use crate::types::get_classifier_model_data;
-use crate::types::{ModelType, ClassifierModelData, LLMModelData, ModelDetailsHistory, ModelEvaluationResult, get_llm_model_data};
+use crate::types::{ModelType, ClassifierModelData, LLMModelData, ModelDetailsHistory, ModelEvaluationResult, LanguageEvaluationResult, get_llm_model_data};
 
 #[ic_cdk::update]
 pub fn add_classifier_model(model_name: String, model_details: ModelDetails) -> u128 {
@@ -204,7 +204,13 @@ pub fn get_model(model_id: u128) -> Model {
 
     model_data.evaluations = model_data.evaluations.into_iter().map(|mut evaluation: ModelEvaluationResult| {
         evaluation.data_points = None;
+        evaluation.llm_data_points = None;
         evaluation
+    }).collect();
+
+    model_data.language_evaluations = model_data.language_evaluations.into_iter().map(|mut levaluation: LanguageEvaluationResult| {
+        levaluation.data_points = Vec::new();
+        levaluation
     }).collect();
 
     model.model_type = ModelType::LLM(model_data);

--- a/src/FAI3_backend/src/model.rs
+++ b/src/FAI3_backend/src/model.rs
@@ -208,7 +208,9 @@ pub fn get_model(model_id: u128) -> Model {
         evaluation
     }).collect();
 
+    ic_cdk::println!("Language evaluations: {}", model_data.language_evaluations.len());
     model_data.language_evaluations = model_data.language_evaluations.into_iter().map(|mut levaluation: LanguageEvaluationResult| {
+        ic_cdk::println!("Data points length {} and timestamp {}/{:02}:{:02}", levaluation.data_points.len(), levaluation.timestamp / (24 * 3600), (levaluation.timestamp % (24 * 3600)) / 3600, (levaluation.timestamp % 3600) / 60);
         levaluation.data_points = Vec::new();
         levaluation
     }).collect();

--- a/src/FAI3_backend/src/model.rs
+++ b/src/FAI3_backend/src/model.rs
@@ -70,7 +70,7 @@ pub fn add_classifier_model(model_name: String, model_details: ModelDetails) -> 
 }
 
 #[ic_cdk::update]
-pub fn add_llm_model(model_name: String, hugging_face_url: String, model_details: ModelDetails) -> u128 {
+pub fn add_llm_model(model_name: String, hugging_face_url: String, model_details: ModelDetails, inference_provider: Option<String>) -> u128 {
     only_admin();
     check_cycles_before_action();
 
@@ -104,11 +104,13 @@ pub fn add_llm_model(model_name: String, hugging_face_url: String, model_details
                         evaluations: Vec::new(),
                         average_fairness_metrics: None,
                         language_evaluations: Vec::new(),
+                        inference_provider,
                     }),
                     cached_thresholds: None,
                     cached_selections: None,
                     version: 0,
                 },
+                
             );
 
             id.borrow_mut().set(current_id + 1).unwrap();
@@ -196,6 +198,22 @@ pub fn get_model(model_id: u128) -> Model {
     });
 
     model.prune()
+}
+
+/// Returns a model
+/// For limitations and data size, it won't return LLM data_points
+/// And it won't return LLM metrics history
+#[ic_cdk::query]
+pub fn get_model(model_id: u128) -> Model {
+    let model = MODELS.with(|models| {
+        models
+            .borrow()
+            .get(&model_id)
+            .expect("Model not found")
+            .clone()
+    });
+
+    return model.prune();
 }
 
 #[ic_cdk::update]

--- a/src/FAI3_backend/src/types.rs
+++ b/src/FAI3_backend/src/types.rs
@@ -250,6 +250,7 @@ pub struct LLMModelData {
     pub evaluations: Vec<ModelEvaluationResult>,
     pub average_fairness_metrics: Option<AverageLLMFairnessMetrics>,
     pub language_evaluations: Vec<LanguageEvaluationResult>,
+    pub inference_provider: Option<String>,
 }
 
 impl Default for LLMModelData {
@@ -261,6 +262,7 @@ impl Default for LLMModelData {
             evaluations: Vec::new(),
             average_fairness_metrics: None,
             language_evaluations: Vec::new(),
+            inference_provider: None,
         }
     }
 }

--- a/src/FAI3_backend/src/types.rs
+++ b/src/FAI3_backend/src/types.rs
@@ -91,6 +91,12 @@ pub struct ModelEvaluationResult {
     pub privileged_map: Vec<KeyValuePair>,
     // data_points is to be used in the future,
     // To replace the metrics and metrics_history
+    pub queries: usize,
+    pub max_queries: usize,
+    pub max_errors: u32,
+    pub invalid_responses: u32,
+    pub errors: u32,
+    pub seed: u32,
     pub data_points: Option<Vec<DataPoint>>,
     pub llm_data_points: Option<Vec<LLMDataPoint>>,
     pub prompt_template: Option<String>,

--- a/src/FAI3_backend/src/utils.rs
+++ b/src/FAI3_backend/src/utils.rs
@@ -1,4 +1,5 @@
 use crate::Model;
+use regex::Regex;
 use candid::Principal;
 
 pub fn is_owner(model: &Model, caller: Principal) {
@@ -40,4 +41,13 @@ pub fn seeded_vector_shuffle<T: Clone>(mut elements: Vec<T>, seed: u32) -> Vec<T
     }
     
     elements
+}
+
+pub fn clean_llm_response(text: &String) -> String {
+    let re = Regex::new(r"(?s)<think>.*?</think>").unwrap();
+    re.replace_all(text, "")
+        .replace("\n", " ")
+        .replace("\r", " ")
+        .trim()
+        .to_string()
 }

--- a/src/FAI3_frontend/src/components/Providers.tsx
+++ b/src/FAI3_frontend/src/components/Providers.tsx
@@ -111,30 +111,28 @@ export default function Providers({ children }: { children: React.ReactNode }) {
   };
 
   const fetchModels = async () => {
-    const models: Model[] = connected
-      ? await (webapp?.get_all_models() as Promise<Model[]>)
-      : await FAI3_backend.get_all_models().catch((err) => {
-          console.error(err);
-          return [];
-        });
+    // This code will get the first 1000 models, with offset 0
+    // In the future, we should paginate the results
+    const classifierList: Model[] = connected ?
+      await (webapp?.get_all_models(1000n, 0n, ["classifier"]) as Promise<Model[]>)
+      :
+      await FAI3_backend.get_all_models(1000n, 0n, ["classifier"]).catch((err) => {
+        console.error(err);
+        return [];
+      });
 
-    console.log(models);
-
-    let classifierList = [];
-    let LLMlist = [];
-
-    for (let i = 0; i < models.length; i++) {
-      if ("LLM" in models[i].model_type) {
-        LLMlist.push(models[i]);
-      } else if ("Classifier" in models[i].model_type) {
-        classifierList.push(models[i]);
-      }
-    }
+    const LLMlist: Model[] = connected ?
+      await (webapp?.get_all_models(1000n, 0n, ["llm"]) as Promise<Model[]>)
+      :
+      await FAI3_backend.get_all_models(1000n, 0n, ["llm"]).catch((err) => {
+        console.error(err);
+        return [];
+      });
 
     setLLMModels(LLMlist);
     setClassifierModels(classifierList);
 
-    setModels(models);
+    setModels(classifierList.concat(LLMlist));
 
     // const llmmodels: LLMModel[] = connected ?
     //   await (webapp?.get_all_llm_models() as Promise<LLMModel[]>)

--- a/src/FAI3_frontend/src/pages/Model/LLMDetails.tsx
+++ b/src/FAI3_frontend/src/pages/Model/LLMDetails.tsx
@@ -28,7 +28,7 @@ export default function LLMDetails({ model, metrics, fetchModel }: any) {
 
   const runCAT = async () => {
     setLoading(true);
-    const res = await webapp?.context_association_test(BigInt(modelId!), 5, 1, false);
+    const res = await webapp?.context_association_test(BigInt(modelId!), 5, 1, false, 0);
 
     if (res && typeof res === "object" && res !== null && "Err" in res) {
       console.error("Failed to run context association test:", res.Err);


### PR DESCRIPTION
Adds code for consuming HF inference providers (specifically, the code allows to interact with Novita, but new providers can be added easily).

Also adds methods for getting the datapoints from CAT tests, and other LLM evaluation results.

How to test:

```
# If not set, add HF API KEY
dfx canister call FAI3_backend set_config '("hugging_face_api_key", "<HF API KEY>")'

# Sets "novita" inference provider.
# For now, there's only "novita". Any other value and it will use only Hugging Face.
dfx canister call FAI3_backend set_config '("hugging_face_inference_provider", "novita")'

# Add a LLM
dfx canister call FAI3_backend add_llm_model '("Meta-Llama-3.1-8B-Instruct", "meta-llama/Llama-3.1-8B-Instruct", record {
    description = "Your model description";
    framework = "TensorFlow";
    version = "2.0";
    objective = "Image classification";
    url = "https://example.com/model"
  })'
  # let's assume it returns id = 1
  
  # The call below will use Novita now
  dfx canister call FAI3_backend context_association_test '(1:nat, 10:nat64, 1:nat32, true, 100)'
```