### PR TITLE
Setting inference providers at the model level + transform function for determinism

### DIFF
--- a/src/FAI3_backend/FAI3_backend.did
+++ b/src/FAI3_backend/FAI3_backend.did
@@ -148,6 +148,7 @@ type LLMModelData = record {
      evaluations: vec ModelEvaluationResult;
      language_evaluations: vec LanguageEvaluationResult;
      average_fairness_metrics: opt AverageLLMFairnessMetrics;
+     inference_provider: opt text;
 };
 
 type ModelType = variant {
@@ -276,7 +277,7 @@ service : () -> {
 
     // Model management
     "add_classifier_model": (text, ModelDetails) -> (nat);
-    "add_llm_model": (text, text, ModelDetails) -> (nat);
+    "add_llm_model": (text, text, ModelDetails, opt text) -> (nat);
     "delete_model": (nat) -> ();
     "add_owner": (nat, principal) -> ();
     "get_owners": (nat) -> (vec principal);

--- a/src/FAI3_backend/src/config_management.rs
+++ b/src/FAI3_backend/src/config_management.rs
@@ -5,7 +5,6 @@ use crate::errors::GenericError;
 use crate::admin_management::only_admin;
 
 pub const HUGGING_FACE_API_KEY_CONFIG_KEY: &str = "hugging_face_api_key";
-pub const HUGGING_FACE_INFERENCE_PROVIDER_CONFIG_KEY: &str = "hugging_face_inference_provider";
 
 #[ic_cdk::update]
 pub fn set_config(config_key: String, config_value: String) {

--- a/src/FAI3_backend/src/context_association_test.rs
+++ b/src/FAI3_backend/src/context_association_test.rs
@@ -399,6 +399,17 @@ async fn cat_intersentence_call(hf_model: String, entry: &IntersentenceEntry, se
     }
 }
 
+// Seed cannot be 0 because then the result won't be deterministic 
+fn generate_seed(original_seed: u32, queries: u32) -> u32 {
+    let seed = original_seed * queries + 1;
+
+    if seed == 0 { // overflow edge case
+        return 1;
+    }
+
+    return seed;
+}
+
 /// Execute a series of intersentence Context Association tests against a Hugging Face model.
 ///
 /// # Parameters
@@ -446,7 +457,7 @@ async fn process_context_association_test_intrasentence(
         ic_cdk::println!("Target Bias Type: {}", entry.bias_type);
         let bias_type = entry.bias_type.clone();
 
-        let resp = cat_intrasentence_call(hf_model.clone(), entry, seed * (queries as u32), shuffle_questions).await;
+        let resp = cat_intrasentence_call(hf_model.clone(), entry, generate_seed(seed, queries as u32), shuffle_questions).await;
 
         match resp {
             Ok(data_point) => {
@@ -537,7 +548,7 @@ async fn process_context_association_test_intersentence(
 
         ic_cdk::println!("Target Bias Type: {}", entry.bias_type);
         let bias_type = entry.bias_type.clone();
-        let resp = cat_intersentence_call(hf_model.clone(), entry, seed * (queries as u32), shuffle_questions).await;
+        let resp = cat_intersentence_call(hf_model.clone(), entry, generate_seed(seed, queries as u32), shuffle_questions).await;
 
         match resp {
             Ok(data_point) => {

--- a/src/FAI3_backend/src/inference_providers/lib.rs
+++ b/src/FAI3_backend/src/inference_providers/lib.rs
@@ -1,0 +1,41 @@
+use serde::{Deserialize, Serialize};
+
+pub const HUGGING_FACE_ENDPOINT: &str = "https://api-inference.huggingface.co/models";
+pub const HUGGING_FACE_INFERENCE_PROVIDER_URL: &str = "https://router.huggingface.co";
+
+// OpenAI compatible API request, for inference providers
+#[derive(Serialize, Deserialize, Clone)]
+pub struct OpenAIRequest {
+    pub model: String,
+    pub messages: Vec<OpenAIMessage>,
+    pub max_tokens: Option<u32>,
+    pub seed: Option<u32>,
+    pub do_sample: Option<bool>,
+    pub stream: bool,
+    pub temperature: Option<f32>,
+}
+
+#[derive(Serialize, Deserialize, Clone)]
+pub struct OpenAIMessage {
+    pub role: String,
+    pub content: String,
+}
+
+#[derive(Serialize, Deserialize, Clone)]
+pub struct HuggingFaceRequestParameters {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stop: Option<Vec<char>>,
+    pub max_new_tokens: Option<u32>,
+    pub temperature: Option<f32>,
+    pub return_full_text: Option<bool>,
+    pub decoder_input_details: Option<bool>,
+    pub details: Option<bool>,
+    pub seed: Option<u32>,
+    pub do_sample: Option<bool>,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct HuggingFaceRequest {
+    pub inputs: String,
+    pub parameters: Option<HuggingFaceRequestParameters>,
+}

--- a/src/FAI3_backend/src/inference_providers/mod.rs
+++ b/src/FAI3_backend/src/inference_providers/mod.rs
@@ -1,0 +1,19 @@
+pub mod traits;
+pub mod novita;
+pub mod together;
+pub mod nebius;
+pub mod none;
+pub mod lib;
+
+// Re-export the trait and providers
+pub use traits::InferenceProvider;
+pub use novita::NovitaProvider;
+pub use together::TogetherAIProvider;
+pub use nebius::NebiusProvider;
+pub use none::NoneProvider;
+pub use lib::{
+    HuggingFaceRequestParameters,
+    HuggingFaceRequest,
+    HUGGING_FACE_ENDPOINT,
+    HUGGING_FACE_INFERENCE_PROVIDER_URL,
+};

--- a/src/FAI3_backend/src/inference_providers/nebius.rs
+++ b/src/FAI3_backend/src/inference_providers/nebius.rs
@@ -1,0 +1,57 @@
+pub struct NebiusProvider {}
+
+use super::traits::InferenceProvider;
+use super::lib::{
+    HuggingFaceRequestParameters,
+    HUGGING_FACE_INFERENCE_PROVIDER_URL,
+    OpenAIRequest,
+    OpenAIMessage,
+};
+
+use super::together::TogetherAIResponse;
+
+impl InferenceProvider for NebiusProvider {
+    fn name(&self) -> &str {
+        return "nebius";
+    }
+    
+    fn generate_payload(&self, llm_model: String, input_text: String, parameters: HuggingFaceRequestParameters) -> Result<Vec<u8>, String> {
+        let payload = OpenAIRequest {
+            model: llm_model,
+            messages: vec![
+                OpenAIMessage {
+                    role: "user".to_string(),
+                    content: input_text,
+                }
+            ],
+            stream: false,
+            max_tokens: Some(5000),
+            seed: parameters.seed,
+            do_sample: Some(false),
+            temperature: Some(0.0),
+        };
+
+        return serde_json::to_vec(&payload).map_err(|e| format!("Failed to serialize payload: {}", e));
+    }
+
+    fn get_response_text(&self, response_body: &Vec<u8>) -> Result<String, String> {
+        // Since Nebius uses same format as TogetherAI, we can reuse the same response structure
+        let json_val: serde_json::Value =
+            serde_json::from_slice(&response_body).map_err(|e| e.to_string())?;
+        let nebius_response: TogetherAIResponse = // Reusing TogetherAI response structure
+            serde_json::from_value(json_val).map_err(|e| e.to_string())?;
+        let choice = nebius_response
+            .choices.get(0);
+        if let None = choice {
+            return Err("choices field is empty".to_string());
+        }
+        Ok(choice
+           .unwrap()
+           .message
+           .content.clone())
+    }
+
+    fn endpoint_url(&self, _llm_model: String) -> String {
+        return format!("{}/{}", &HUGGING_FACE_INFERENCE_PROVIDER_URL.to_string(), "nebius/v1/chat/completions");
+    }
+}

--- a/src/FAI3_backend/src/inference_providers/none.rs
+++ b/src/FAI3_backend/src/inference_providers/none.rs
@@ -1,0 +1,60 @@
+use serde::{Deserialize, Serialize};
+
+use crate::types::HuggingFaceResponseItem;
+
+use super::traits::InferenceProvider;
+use super::lib::{
+    HuggingFaceRequestParameters,
+    HuggingFaceRequest,
+    HUGGING_FACE_ENDPOINT,
+};
+
+pub struct NoneProvider {}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct HuggingFaceResponse {
+    generated_text: Option<String>,
+}
+
+impl InferenceProvider for NoneProvider {
+    fn name(&self) -> &str {
+        return "none (Hugging Face API)";
+    }
+    
+    fn generate_payload(&self, _llm_model: String, input_text: String, parameters: HuggingFaceRequestParameters) -> Result<Vec<u8>, String> {
+        let payload = HuggingFaceRequest {
+            inputs: input_text.clone(),
+            parameters: Some(parameters), 
+        };
+
+        let json_payload =
+            serde_json::to_vec(&payload).map_err(|e| format!("Failed to serialize payload: {}", e))?;
+
+        return Ok(json_payload);
+    }
+
+    fn get_response_text(&self, response_body: &Vec<u8>) -> Result<String, String> {
+        // 1) Parse raw bytes into a `serde_json::Value`
+        let json_val: serde_json::Value =
+            serde_json::from_slice(&response_body).map_err(|e| e.to_string())?;
+        
+        // 2) Now parse that `json_val` into a vector of your items
+        let hf_response: Vec<HuggingFaceResponseItem> =
+            serde_json::from_value(json_val).map_err(|e| e.to_string())?;
+
+        // 3) Extract the text from the first item, or default
+        let items = hf_response.get(0);
+
+        if let None = items {
+            return Err("No generated text".to_string());
+        }
+
+        return Ok(items
+                  .and_then(|item| item.generated_text.clone())
+                  .unwrap_or_else(|| "No generated_text".to_string()));
+    }
+
+    fn endpoint_url(&self, llm_model: String) -> String {
+        return format!("{}/{}", HUGGING_FACE_ENDPOINT, llm_model);
+    }
+}

--- a/src/FAI3_backend/src/inference_providers/novita.rs
+++ b/src/FAI3_backend/src/inference_providers/novita.rs
@@ -1,0 +1,121 @@
+pub struct NovitaProvider {}
+
+use serde::{Deserialize, Serialize};
+
+use super::traits::InferenceProvider;
+use super::lib::{
+    HuggingFaceRequestParameters,
+    HUGGING_FACE_INFERENCE_PROVIDER_URL,
+    OpenAIRequest,
+    OpenAIMessage,
+};
+
+// Novita JSON response
+#[derive(Serialize, Deserialize)]
+struct NovitaResponse {
+    choices: Vec<NovitaChoice>,
+    created: i64,
+    id: String,
+    model: String,
+    object: String,
+    system_fingerprint: String,
+    usage: NovitaUsage,
+}
+
+#[derive(Serialize, Deserialize)]
+struct NovitaChoice {
+    content_filter_results: NovitaContentFilterResults,
+    finish_reason: String,
+    index: i32,
+    message: NovitaMessage,
+}
+
+#[derive(Serialize, Deserialize)]
+struct NovitaContentFilterResults {
+    hate: NovitaFilterResult,
+    jailbreak: NovitaJailbreakResult,
+    profanity: NovitaFilterResult,
+    self_harm: NovitaFilterResult,
+    sexual: NovitaFilterResult,
+    violence: NovitaFilterResult,
+}
+
+#[derive(Serialize, Deserialize)]
+struct NovitaFilterResult {
+    filtered: bool,
+    #[serde(default)]
+    detected: bool,
+}
+
+#[derive(Serialize, Deserialize)]
+struct NovitaJailbreakResult {
+    detected: bool,
+    filtered: bool,
+}
+
+#[derive(Serialize, Deserialize)]
+struct NovitaMessage {
+    content: String,
+    role: String,
+}
+
+#[derive(Serialize, Deserialize)]
+struct NovitaUsage {
+    completion_tokens: i32,
+    completion_tokens_details: Option<serde_json::Value>,
+    prompt_tokens: i32,
+    prompt_tokens_details: Option<serde_json::Value>,
+    total_tokens: i32,
+}
+
+impl InferenceProvider for NovitaProvider {
+    fn name(&self) -> &str {
+        return "novita";
+    }
+    
+    fn generate_payload(&self, llm_model: String, input_text: String, parameters: HuggingFaceRequestParameters) -> Result<Vec<u8>, String> {
+        let payload = OpenAIRequest {
+            model: llm_model.to_lowercase(),
+            messages: vec![
+                OpenAIMessage {
+                    role: "user".to_string(),
+                    content: input_text,
+                }
+            ],
+            stream: false,
+            max_tokens: Some(5000),
+            seed: parameters.seed,
+            do_sample: Some(false),
+            temperature: Some(0.0),
+        };
+
+        return serde_json::to_vec(&payload).map_err(|e| format!("Failed to serialize payload: {}", e));
+    }
+
+    fn get_response_text(&self, response_body: &Vec<u8>) -> Result<String, String> {
+        // 1) Parse raw bytes into a `serde_json::Value`
+        let json_val: serde_json::Value =
+            serde_json::from_slice(&response_body).map_err(|e| e.to_string())?;
+        
+        // 2) Now parse that `json_val` into a vector of your items
+        let hf_response: NovitaResponse =
+            serde_json::from_value(json_val).map_err(|e| e.to_string())?;
+
+        // 3) Extract the text from the first item, or default
+        let choice = hf_response
+            .choices.get(0);
+
+        if let None = choice {
+            return Err("choices fields is empty".to_string());
+        }
+
+        Ok(choice
+           .unwrap()
+           .message
+           .content.clone())
+    }
+
+    fn endpoint_url(&self, _llm_model: String) -> String {
+        return format!("{}/{}", &HUGGING_FACE_INFERENCE_PROVIDER_URL.to_string(), "novita/v3/openai/chat/completions");
+    }
+}

--- a/src/FAI3_backend/src/inference_providers/together.rs
+++ b/src/FAI3_backend/src/inference_providers/together.rs
@@ -1,0 +1,97 @@
+use serde::{Deserialize, Serialize};
+
+pub struct TogetherAIProvider {}
+
+use super::traits::InferenceProvider;
+use super::lib::{
+    HuggingFaceRequestParameters,
+    HUGGING_FACE_INFERENCE_PROVIDER_URL,
+    OpenAIRequest,
+    OpenAIMessage,
+};
+
+// TogetherAI JSON response
+#[derive(Serialize, Deserialize)]
+pub struct TogetherAIResponse {
+    pub id: String,
+    pub object: String,
+    pub created: i64,
+    pub model: String,
+    pub prompt: Option<Vec<String>>,
+    pub choices: Vec<TogetherAIChoice>,
+    pub usage: TogetherAIUsage,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct TogetherAIChoice {
+    pub finish_reason: String,
+    pub seed: Option<u32>,
+    pub logprobs: Option<serde_json::Value>,
+    pub index: i32,
+    pub message: TogetherAIMessage,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct TogetherAIMessage {
+    pub role: String,
+    pub content: String,
+    pub tool_calls: Vec<serde_json::Value>,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct TogetherAIUsage {
+    pub prompt_tokens: i32,
+    pub completion_tokens: i32,
+    pub total_tokens: i32,
+}
+
+impl InferenceProvider for TogetherAIProvider {
+    fn name(&self) -> &str {
+        return "togetherai";
+    }
+    
+    fn generate_payload(&self, llm_model: String, input_text: String, parameters: HuggingFaceRequestParameters) -> Result<Vec<u8>, String> {
+        let payload = OpenAIRequest {
+            model: llm_model.to_lowercase(),
+            messages: vec![
+                OpenAIMessage {
+                    role: "user".to_string(),
+                    content: input_text,
+                }
+            ],
+            stream: false,
+            max_tokens: Some(5000),
+            seed: parameters.seed,
+            do_sample: Some(false),
+            temperature: Some(0.0),
+        };
+
+        return serde_json::to_vec(&payload).map_err(|e| format!("Failed to serialize payload: {}", e));
+    }
+
+    fn get_response_text(&self, response_body: &Vec<u8>) -> Result<String, String> {
+        // Parse raw bytes into TogetherAI response format
+        let json_val: serde_json::Value =
+            serde_json::from_slice(&response_body).map_err(|e| e.to_string())?;
+        
+        let together_response: TogetherAIResponse =
+            serde_json::from_value(json_val).map_err(|e| e.to_string())?;
+
+        // Extract the text from the first choice
+        let choice = together_response
+            .choices.get(0);
+
+        if let None = choice {
+            return Err("choices field is empty".to_string());
+        }
+
+        Ok(choice
+           .unwrap()
+           .message
+           .content.clone())
+    }
+
+    fn endpoint_url(&self, _llm_model: String) -> String {
+        return format!("{}/{}", &HUGGING_FACE_INFERENCE_PROVIDER_URL.to_string(), "together/v1/chat/completions");
+    }
+}

--- a/src/FAI3_backend/src/inference_providers/traits.rs
+++ b/src/FAI3_backend/src/inference_providers/traits.rs
@@ -1,0 +1,8 @@
+use super::lib::HuggingFaceRequestParameters;
+
+pub trait InferenceProvider {
+    fn name(&self) -> &str;
+    fn generate_payload(&self, llm_model: String, input_text: String, parameters: HuggingFaceRequestParameters) -> Result<Vec<u8>, String>;
+    fn get_response_text(&self, response_body: &Vec<u8>) -> Result<String, String>;
+    fn endpoint_url(&self, llm_model: String) -> String;
+}

--- a/src/FAI3_backend/src/lib.rs
+++ b/src/FAI3_backend/src/lib.rs
@@ -11,6 +11,7 @@ pub mod llm_language_evaluations;
 mod utils;
 pub mod errors;
 mod config_management;
+pub mod inference_providers;
 
 use errors::GenericError;
 use candid::Principal;

--- a/src/FAI3_backend/src/llm_fairness.rs
+++ b/src/FAI3_backend/src/llm_fairness.rs
@@ -243,7 +243,7 @@ pub fn build_prompts(records: &Vec<HashMap<String, String>>, predict_attribute: 
 /// Asynchronously runs metrics calculation based on provided parameters.
 ///
 /// # Arguments
-/// * `hf_model` - A string representing the model for Hugging face.
+/// * `model_data` - LLM Model data.
 /// * `seed` - An unsigned 32-bit integer used as the seed for both Hugging Face and examples shuffling.
 /// * `max_queries` - The maximum number of queries. Set to 0 for infinite.
 /// * `train_csv` - Full CSV with train data.
@@ -260,7 +260,7 @@ pub fn build_prompts(records: &Vec<HashMap<String, String>>, predict_attribute: 
 ///   and two `u32` values representing wrong responses and call errors.
 /// * On failure: A string indicating the error.
 async fn run_metrics_calculation(
-    hf_model: String, seed: u32, max_queries: usize,
+    model_data: &LLMModelData, seed: u32, max_queries: usize,
     train_csv: &str, test_csv: &str, _cf_test_csv: &str,
     sensible_attribute: &str, predict_attribute: &str, data_points: &mut Vec<LLMDataPoint>,
     prompt_template: String,
@@ -364,7 +364,7 @@ async fn run_metrics_calculation(
 
         let timestamp: u64 = ic_cdk::api::time();
         
-        let res = call_hugging_face(personalized_prompt.clone(), hf_model.clone(), seed, Some(hf_parameters.clone())).await;
+        let res = call_hugging_face(personalized_prompt.clone(), model_data.hugging_face_url.clone(), seed, Some(hf_parameters.clone()), &model_data.inference_provider).await;
         
         match res {
             Ok(r) => {
@@ -384,7 +384,7 @@ async fn run_metrics_calculation(
                 };
 
                 let timestamp_cf: u64 = ic_cdk::api::time();
-                let res_cf = call_hugging_face(personalized_prompt_cf.clone(), hf_model.clone(), seed, Some(hf_parameters.clone())).await;
+                let res_cf = call_hugging_face(personalized_prompt_cf.clone(), model_data.hugging_face_url.clone(), seed, Some(hf_parameters.clone()), &model_data.inference_provider).await;
 
                 let counter_factual: LLMDataPointCounterFactual = match res_cf {
                     Ok(val) => {
@@ -591,8 +591,8 @@ pub async fn calculate_llm_metrics(llm_model_id: u128, dataset: String, max_quer
     let model = model.unwrap();
     is_owner(&model, caller);
 
-    let hf_model = if let ModelType::LLM(model_data) = model.model_type {
-        model_data.hugging_face_url
+    let model_data = if let ModelType::LLM(model_data) = model.model_type {
+        model_data
     } else {
         return Err("Model should be a LLM".to_string());
     };
@@ -618,7 +618,7 @@ pub async fn calculate_llm_metrics(llm_model_id: u128, dataset: String, max_quer
             sensible_attribute = String::from(ds.sensible_attribute);
             prompt_template = String::from(ds.prompt_template);
 
-            res = run_metrics_calculation(hf_model, seed, max_queries, train_csv, test_csv, cf_test_csv,
+            res = run_metrics_calculation(&model_data, seed, max_queries, train_csv, test_csv, cf_test_csv,
                                           ds.sensible_attribute, ds.predict_attribute, &mut data_points,
                                           prompt_template.clone(), ds.sensible_attribute_values,
                                           ds.predict_attributes_values,

--- a/src/FAI3_backend/src/llm_fairness.rs
+++ b/src/FAI3_backend/src/llm_fairness.rs
@@ -1,5 +1,6 @@
 use ic_cdk_macros::*;
-use crate::hugging_face::{call_hugging_face, HuggingFaceRequestParameters};
+use crate::inference_providers::lib::HuggingFaceRequestParameters;
+use crate::hugging_face::call_hugging_face;
 use crate::types::{DataPoint, LLMDataPoint, ModelType, LLMMetricsAPIResult, Metrics, AverageMetrics, get_llm_model_data, ModelEvaluationResult, PrivilegedMap, KeyValuePair, LLMDataPointCounterFactual, CounterFactualModelEvaluationResult, AverageLLMFairnessMetrics, LLMModelData};
 use crate::{check_cycles_before_action, MODELS, NEXT_LLM_MODEL_EVALUATION_ID, get_model_from_memory};
 use crate::utils::{is_owner, select_random_element, seeded_vector_shuffle};

--- a/src/FAI3_backend/src/llm_language_evaluations.rs
+++ b/src/FAI3_backend/src/llm_language_evaluations.rs
@@ -1,5 +1,6 @@
 use ic_cdk_macros::*;
-use crate::hugging_face::{call_hugging_face, HuggingFaceRequestParameters};
+use crate::hugging_face::call_hugging_face;
+use crate::inference_providers::lib::HuggingFaceRequestParameters;
 use crate::types::{LanguageEvaluationResult, LanguageEvaluationMetrics, ModelType, LLMModelData, LanguageEvaluationDataPoint, get_llm_model_data};
 use crate::{check_cycles_before_action, NEXT_LLM_LANGUAGE_EVALUATION_ID, get_model_from_memory, only_admin};
 use crate::utils::{is_owner, seeded_vector_shuffle};

--- a/src/FAI3_backend/src/llm_language_evaluations.rs
+++ b/src/FAI3_backend/src/llm_language_evaluations.rs
@@ -121,7 +121,7 @@ async fn run_evaluate_languages(model_data: &LLMModelData, languages: &Vec<Strin
 
             let prompt: String = build_prompt(&question, &options, seed * (queries as u32));
             
-            let res = call_hugging_face(prompt.clone(), model_data.hugging_face_url.clone(), seed, Some(hf_parameters.clone())).await;
+            let res = call_hugging_face(prompt.clone(), model_data.hugging_face_url.clone(), seed, Some(hf_parameters.clone()), &model_data.inference_provider).await;
 
             let trimmed_response = match res {
                 Ok(response) => crate::utils::clean_llm_response(&response),

--- a/src/FAI3_backend/src/model.rs
+++ b/src/FAI3_backend/src/model.rs
@@ -141,7 +141,6 @@ pub fn get_all_models(limit: usize, _offset: usize, model_type: Option<String>) 
         return models
             .values()
             .filter(|model| {
-                ic_cdk::println!("Filtering");
                 match &model_type {
                     Some(ref mt) if mt == "llm" => matches!(model.model_type, ModelType::LLM(_)),
                     Some(ref mt) if mt == "classifier" => matches!(model.model_type, ModelType::Classifier(_)),

--- a/src/FAI3_backend/src/model.rs
+++ b/src/FAI3_backend/src/model.rs
@@ -141,6 +141,7 @@ pub fn get_all_models(limit: usize, _offset: usize, model_type: Option<String>) 
         return models
             .values()
             .filter(|model| {
+                ic_cdk::println!("Filtering");
                 match &model_type {
                     Some(ref mt) if mt == "llm" => matches!(model.model_type, ModelType::LLM(_)),
                     Some(ref mt) if mt == "classifier" => matches!(model.model_type, ModelType::Classifier(_)),
@@ -196,6 +197,22 @@ pub fn get_model(model_id: u128) -> Model {
     });
 
     model.prune()
+}
+
+/// Returns a model
+/// For limitations and data size, it won't return LLM data_points
+/// And it won't return LLM metrics history
+#[ic_cdk::query]
+pub fn get_model(model_id: u128) -> Model {
+    let model = MODELS.with(|models| {
+        models
+            .borrow()
+            .get(&model_id)
+            .expect("Model not found")
+            .clone()
+    });
+
+    return model.prune();
 }
 
 #[ic_cdk::update]

--- a/src/FAI3_backend/src/model.rs
+++ b/src/FAI3_backend/src/model.rs
@@ -70,7 +70,7 @@ pub fn add_classifier_model(model_name: String, model_details: ModelDetails) -> 
 }
 
 #[ic_cdk::update]
-pub fn add_llm_model(model_name: String, hugging_face_url: String, model_details: ModelDetails) -> u128 {
+pub fn add_llm_model(model_name: String, hugging_face_url: String, model_details: ModelDetails, inference_provider: Option<String>) -> u128 {
     only_admin();
     check_cycles_before_action();
 
@@ -104,11 +104,13 @@ pub fn add_llm_model(model_name: String, hugging_face_url: String, model_details
                         evaluations: Vec::new(),
                         average_fairness_metrics: None,
                         language_evaluations: Vec::new(),
+                        inference_provider,
                     }),
                     cached_thresholds: None,
                     cached_selections: None,
                     version: 0,
                 },
+                
             );
 
             id.borrow_mut().set(current_id + 1).unwrap();

--- a/src/FAI3_backend/src/types.rs
+++ b/src/FAI3_backend/src/types.rs
@@ -250,6 +250,7 @@ pub struct LLMModelData {
     pub evaluations: Vec<ModelEvaluationResult>,
     pub average_fairness_metrics: Option<AverageLLMFairnessMetrics>,
     pub language_evaluations: Vec<LanguageEvaluationResult>,
+    pub inference_provider: Option<String>,
 }
 
 impl Default for LLMModelData {
@@ -261,6 +262,7 @@ impl Default for LLMModelData {
             evaluations: Vec::new(),
             average_fairness_metrics: None,
             language_evaluations: Vec::new(),
+            inference_provider: None,
         }
     }
 }


### PR DESCRIPTION
Add inference provider at the model level.

When creating a model, an inference provider can be specified:

```
dfx canister call FAI3_backend add_llm_model '("mistralai/Mistral-Nemo-Instruct-2407 (Nebius)", "mistralai/Mistral-Nemo-Instruct-2407", record {
    description = "Your model description";
    framework = "TensorFlow";
    version = "2.0";
    objective = "Image classification";
    url = "https://example.com/model"
  }, opt "nebius")'
  ```
  
  Supported: nebius, togetherai and novita.
  
  If null, it will use Hugging Face.
  
  More examples:
  
  ```
  dfx canister call FAI3_backend add_llm_model '("mistralai/Mistral-7B-Instruct-v0.3 (togetherai)", "mistralai/Mistral-7B-Instruct-v0.3", record {
    description = "Your model description";
    framework = "TensorFlow";
    version = "2.0";
    objective = "Image classification";
    url = "https://example.com/model"
  }, opt "togetherai")'
  ```

```
dfx canister call FAI3_backend add_llm_model '("Meta-Llama-3.1-8B-Instruct (Novita)", "meta-llama/Llama-3.1-8B-Instruct", record {
    description = "Your model description";
    framework = "TensorFlow";
    version = "2.0";
    objective = "Image classification";
    url = "https://example.com/model"
  }, opt "novita")'
  ```
  
Hugging Face:
  
    
  ```
  dfx canister call FAI3_backend add_llm_model '("Meta-Llama-3.1-8B-Instruct (HF)", "meta-llama/Llama-3.1-8B-Instruct", record {
    description = "Your model description";
    framework = "TensorFlow";
    version = "2.0";
    objective = "Image classification";
    url = "https://example.com/model"
  }, null)'
  ```
  
  It also adds a transform function for removing non-determinism from "created" and "id" fields returned by HF when consuming inference providers. This only fixes non-determinism for these fields, but not for different LLM answers.