### PR TITLE
Fairness fix

### DIFF
--- a/src/FAI3_backend/src/llm_fairness.rs
+++ b/src/FAI3_backend/src/llm_fairness.rs
@@ -698,8 +698,9 @@ pub fn calculate_counter_factual_metrics(
                 continue;
             }
 
-            match cf.target {
-                true => {
+            // Only the sensible feature is saved for LLMs, so len should be 1
+            match dp.features.get(0).expect("Feature 0 should be defined") {
+                1.0 => {
                     total_sensible_attr1 += 1;
 
                     if dp.valid != cf.valid {
@@ -708,8 +709,8 @@ pub fn calculate_counter_factual_metrics(
                     if dp.valid && cf.valid && dp.predicted != cf.predicted {
                         changed_sensible_attr1 += 1;
                     }
-                }
-                false => {
+                },
+                _ => {
                     total_sensible_attr0 += 1;
 
                     if dp.valid != cf.valid {


### PR DESCRIPTION
Counterfactual per sensible attribute should be calculated using the sensible attribute, not the target.

This PR also removes a duplicated method.